### PR TITLE
add sasl-protected mail relay configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ None
  * `postfix_hostname` [default: `{{ ansible_fqdn }}`]: Host name, used for `myhostname` and in `mydestination`
  * `postfix_mailname` [default: `{{ ansible_fqdn }}`]: Mail name (in `/etc/mailname`), used for `myorigin`
  * `postfix_aliases` [default: `[]`]: Aliases to ensure present in `/etc/aliases`
-
+ * `postfix_relayhost` [default: `no` (i.e., no relay host)]: Hostname to relay all email to
+ * `postfix_relayport` [default: 587]: Relay port (on postfix_relayhost, if set)
+ * `postfix_sasl_user` [default: `postmaster@{{ ansible_domain }}`]: SASL relay username
+ * `postfix_sasl_password` [default: `password`]: SASL relay password
+ 
 ## Dependencies
 
 * `debconf`
@@ -20,11 +24,32 @@ None
 
 #### Example
 
+A simple example that doesn't use SASL relaying:
 ```yaml
 ---
 - hosts: all
   roles:
   - postfix
+  vars:
+    postfix_aliases:
+    - { user: root, alias: you@yourdomain.org }
+```
+
+Provide the relay host name if you want to enable relaying:
+```yaml
+---
+- hosts: all
+  roles:
+  - postfix
+  vars:
+    postfix_aliases:
+    - { user: root, alias: you@yourdomain.org }
+    postfix_relayhost: mail.yourdomain.org
+```
+
+You'll probably want to provide the password on the command line when you run the playbook:
+```
+--extra-vars postfix_sasl_password=your_relay_pw
 ```
 
 #### License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,7 @@ postfix_install:
 postfix_hostname: "{{ ansible_fqdn }}"
 postfix_mailname: "{{ ansible_fqdn }}"
 postfix_aliases: []
+postfix_relayhost: no
+postfix_relayhost_port: 587
+postfix_sasl_user: "postmaster@{{ ansible_domain }}"
+postfix_sasl_password: "password"

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -32,9 +32,17 @@ myhostname = {{ postfix_hostname }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 mydestination = {{ postfix_hostname }}, localdomain, localhost, localhost.localdomain
-relayhost =
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
 recipient_delimiter = +
 inet_interfaces = all
 inet_protocols = ipv4
+
+{% if postfix_relayhost %}
+relayhost = [{{ postfix_relayhost }}]:{{ postfix_relayhost_port }}
+smtp_sasl_auth_enable = yes
+smtp_sasl_password_maps = static:{{ postfix_sasl_user }}:{{ postfix_sasl_password }}
+smtp_sasl_security_options = noanonymous
+{% else %}
+relayhost =
+{% endif %}


### PR DESCRIPTION
Hi, thanks for this playbook.  I added the ability to configure a node to relay all mail over an sasl-protected connection.  Hope it's useful.
