### PR TITLE
Add AWS SES compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ None
  * `postfix_aliases` [default: `[]`]: Aliases to ensure present in `/etc/aliases`
  * `postfix_relayhost` [default: `false` (no relay host)]: Hostname to relay all email to
  * `postfix_relayport` [default: 587]: Relay port (on postfix_relayhost, if set)
+ * `postfix_relaytls` [default: `false`]: Use TLS when sending with a relay host
  * `postfix_sasl_user` [default: `postmaster@{{ ansible_domain }}`]: SASL relay username
  * `postfix_sasl_password` [default: `k8+haga4@#pR`]: SASL relay password
  
@@ -47,6 +48,21 @@ Provide the relay host name if you want to enable relaying:
     postfix_aliases:
     - { user: root, alias: you@yourdomain.org }
     postfix_relayhost: mail.yourdomain.org
+```
+
+For AWS SES support:
+```yaml
+- hosts: all
+  roles:
+  - postfix
+  vars:
+    postfix_aliases:
+    - { user: root, alias: sesverified@yourdomain.org }
+    postfix_relayhost: email-smtp.us-east-1.amazonaws.com
+    postfix_relaytls: yes
+    # AWS IAM SES credentials (not access key):
+    postfix_sasl_user: AKIXXXXXXXXXXXXXXXXX
+    postfix_sasl_password: ASDFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
 #### License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,5 +11,6 @@ postfix_mailname: "{{ ansible_fqdn }}"
 postfix_aliases: []
 postfix_relayhost: false
 postfix_relayhost_port: 587
+postfix_relaytls: false
 postfix_sasl_user: "postmaster@{{ ansible_domain }}"
 postfix_sasl_password: 'k8+haga4@#pR'

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -43,6 +43,11 @@ relayhost = [{{ postfix_relayhost }}]:{{ postfix_relayhost_port }}
 smtp_sasl_auth_enable = yes
 smtp_sasl_password_maps = static:{{ postfix_sasl_user }}:{{ postfix_sasl_password }}
 smtp_sasl_security_options = noanonymous
+{% if postfix_relaytls %}
+smtp_use_tls = yes
+smtp_tls_security_level = encrypt
+smtp_tls_note_starttls_offer = yes
+{% endif %}
 {% else %}
 relayhost =
 {% endif %}


### PR DESCRIPTION
* Add variable `postfix_relaytls` to enable use of TLS per [SES Postfix documentation]
* Add AWS SES usage example in README

[SES Postfix documentation]: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/postfix.html