### PR TITLE
Reset inet_protocols to the Postfix >=2.9 default of 'all' to enable IPv6

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,4 @@ postfix_relaytls: false
 postfix_sasl_user: "postmaster@{{ ansible_domain }}"
 postfix_sasl_password: 'k8+haga4@#pR'
 postfix_inet_interfaces: all
+postfix_inet_protocols: all

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -36,7 +36,7 @@ mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
 recipient_delimiter = +
 inet_interfaces = {{ postfix_inet_interfaces }}
-inet_protocols = ipv4
+inet_protocols = all
 
 {% if postfix_relayhost %}
 relayhost = [{{ postfix_relayhost }}]:{{ postfix_relayhost_port }}

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -36,7 +36,7 @@ mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
 recipient_delimiter = +
 inet_interfaces = {{ postfix_inet_interfaces }}
-inet_protocols = all
+inet_protocols = {{ postfix_inet_protocols }}
 
 {% if postfix_relayhost %}
 relayhost = [{{ postfix_relayhost }}]:{{ postfix_relayhost_port }}


### PR DESCRIPTION
The default value for inet_protocols has been 'all' since Postfix 2.9 (http://www.postfix.org/postconf.5.html#inet_protocols), which will enable IPv6.
Seems to me that the default should be to use IPv6 where available.