### PR TITLE
add optional sender_canonical_maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ None
  * `postfix_hostname` [default: `{{ ansible_fqdn }}`]: Host name, used for `myhostname` and in `mydestination`
  * `postfix_mailname` [default: `{{ ansible_fqdn }}`]: Mail name (in `/etc/mailname`), used for `myorigin`
  * `postfix_aliases` [default: `[]`]: Aliases to ensure present in `/etc/aliases`
+ * `postfix_sender_canonical_maps` [default: `[]`]: Sender address rewriting in `/etc/postfix/sender_canonical_maps` ([see](http://www.postfix.org/postconf.5.html#sender_canonical_maps))
  * `postfix_mynetworks` [default: `['127.0.0.0/8', '[::ffff:127.0.0.0]/104', '[::1]/128']`]: The list of "trusted" remote SMTP clients that have more privileges than "strangers"
  * `postfix_inet_interfaces` [default: `all`]: Network interfaces to bind ([see](http://www.postfix.org/postconf.5.html#inet_interfaces))
  * `postfix_inet_protocols` [default: `all`]: The Internet protocols Postfix will attempt to use when making or accepting connections ([see](http://www.postfix.org/postconf.5.html#inet_protocols))
@@ -25,7 +26,7 @@ None
  * `postfix_smtp_tls_cafile` [optional]: A file containing CA certificates of root CAs trusted to sign either remote SMTP server certificates or intermediate CA certificates (e.g. `/etc/ssl/certs/ca-certificates.crt`)
  * `postfix_sasl_user` [default: `postmaster@{{ ansible_domain }}`]: SASL relay username
  * `postfix_sasl_password` [default: `k8+haga4@#pR`]: SASL relay password **Make sure to change!**
- 
+
 ## Dependencies
 
 * `debconf`
@@ -43,6 +44,18 @@ A simple example that doesn't use SASL relaying:
     postfix_aliases:
       - user: root
         alias: you@yourdomain.org
+```
+
+A simple example that rewrites the sender address:
+```yaml
+---
+- hosts: all
+  roles:
+    - postfix
+  vars:
+    postfix_sender_canonical_maps:
+      - sender: root
+        rewrite: postmaster@example.com
 ```
 
 Provide the relay host name if you want to enable relaying:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ postfix_install:
 postfix_hostname: "{{ ansible_fqdn }}"
 postfix_mailname: "{{ ansible_fqdn }}"
 postfix_aliases: []
+postfix_sender_canonical_maps: []
 postfix_relayhost: false
 postfix_relayhost_port: 587
 postfix_relaytls: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,3 +10,6 @@
 
 - name: postmap sasl_passwd
   command: postmap hash:/etc/postfix/sasl_passwd
+
+- name: postmap sender_canonical_maps
+  command: postmap hash:/etc/postfix/sender_canonical_maps

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,6 +83,22 @@
     - postfix
     - postfix-aliases
 
+- name: configure sender canonical maps
+  lineinfile:
+    dest: /etc/postfix/sender_canonical_maps
+    regexp: '^{{ item.sender }}.*'
+    line: '{{ item.sender }} {{ item.rewrite }}'
+    owner: root
+    group: root
+    mode: 0644
+    create: yes
+    state: present
+  with_items: "{{ postfix_sender_canonical_maps }}"
+  when: postfix_sender_canonical_maps
+  notify:
+    - postmap sender_canonical_maps
+    - restart postfix
+
 - name: start and enable service
   service:
     name: postfix

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -31,6 +31,9 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 myhostname = {{ postfix_hostname }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
+{% if postfix_sender_canonical_maps %}
+sender_canonical_maps = hash:/etc/postfix/sender_canonical_maps
+{% endif %}
 mydestination = {{ postfix_hostname }}, localdomain, localhost, localhost.localdomain
 mynetworks = {{ postfix_mynetworks | join(' ') }}
 mailbox_size_limit = 0


### PR DESCRIPTION
Hi @tersmitten,

this PR allows the user to optionally configure the sender_canonical_maps feature of Postix which allow rewriting of the sender.
We have a use case here where the relayhost of the provider only accepts certain sender names.

Let me know if you'd like to have any changes on this.

Best 

Jard