### PR TITLE
Make smtpd_banner configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ None
  * `postfix_smtp_tls_cafile` [optional]: A file containing CA certificates of root CAs trusted to sign either remote SMTP server certificates or intermediate CA certificates (e.g. `/etc/ssl/certs/ca-certificates.crt`)
  * `postfix_sasl_user` [default: `postmaster@{{ ansible_domain }}`]: SASL relay username
  * `postfix_sasl_password` [default: `k8+haga4@#pR`]: SASL relay password **Make sure to change!**
+ * `postfix_smtpd_banner` [default: `$myhostname ESMTP $mail_name (Ubuntu)`]: Greeting banner **You MUST specify $myhostname at the start of the text. This is required by the SMTP protocol.**
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,4 @@ postfix_mynetworks:
   - 127.0.0.0/8
   - '[::ffff:127.0.0.0]/104'
   - '[::1]/128'
+postfix_smtpd_banner: "$myhostname ESMTP $mail_name (Ubuntu)"

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -7,7 +7,7 @@
 # is /etc/mailname.
 myorigin = /etc/mailname
 
-smtpd_banner = $myhostname ESMTP $mail_name (Ubuntu)
+smtpd_banner = {{ postfix_smtpd_banner }}
 biff = no
 
 # appending .domain is the MUA's job.


### PR DESCRIPTION
Allowing custom smtpd_banner can be useful to prevent announcing software or version to malicious people or scripts.
Reference: https://cisofy.com/controls/MAIL-8818/