### PR TITLE
Disable the SMTP VRFY command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ None
  * `postfix_sasl_user` [default: `postmaster@{{ ansible_domain }}`]: SASL relay username
  * `postfix_sasl_password` [default: `k8+haga4@#pR`]: SASL relay password **Make sure to change!**
  * `postfix_smtpd_banner` [default: `$myhostname ESMTP $mail_name (Ubuntu)`]: Greeting banner **You MUST specify $myhostname at the start of the text. This is required by the SMTP protocol.**
+ * `postfix_disable_vrfy_command` [default: `no`]: Disable the SMTP VRFY command. This stops some techniques used to harvest email addresses.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,4 @@ postfix_mynetworks:
   - '[::ffff:127.0.0.0]/104'
   - '[::1]/128'
 postfix_smtpd_banner: '$myhostname ESMTP $mail_name (Ubuntu)'
+postfix_disable_vrfy_command: no

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -59,3 +59,6 @@ smtp_tls_CAfile = {{ postfix_smtp_tls_cafile }}
 {% else %}
 relayhost =
 {% endif %}
+
+# Disable the SMTP VRFY command. This stops some techniques used to harvest email addresses.
+disable_vrfy_command = {{ postfix_disable_vrfy_command }}


### PR DESCRIPTION
Disable the SMTP VRFY command. This stops some techniques used to harvest email addresses.

https://linux-audit.com/postfix-hardening-guide-for-security-and-privacy/