### PR TITLE
Virtual aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ None
  * `postfix_hostname` [default: `{{ ansible_fqdn }}`]: Host name, used for `myhostname` and in `mydestination`
  * `postfix_mailname` [default: `{{ ansible_fqdn }}`]: Mail name (in `/etc/mailname`), used for `myorigin`
  * `postfix_aliases` [default: `[]`]: Aliases to ensure present in `/etc/aliases`
+ * `postfix_virtual_aliases` [default: `[]`]: Virtual aliases to ensure present in `/etc/postfix/virtual`
  * `postfix_sender_canonical_maps` [default: `[]`]: Sender address rewriting in `/etc/postfix/sender_canonical_maps` ([see](http://www.postfix.org/postconf.5.html#sender_canonical_maps))
  * `postfix_mynetworks` [default: `['127.0.0.0/8', '[::ffff:127.0.0.0]/104', '[::1]/128']`]: The list of "trusted" remote SMTP clients that have more privileges than "strangers"
  * `postfix_inet_interfaces` [default: `all`]: Network interfaces to bind ([see](http://www.postfix.org/postconf.5.html#inet_interfaces))
@@ -45,6 +46,20 @@ A simple example that doesn't use SASL relaying:
     postfix_aliases:
       - user: root
         alias: you@yourdomain.org
+```
+
+A simple example with virtual aliases for mail forwarding that doesn't use SASL relaying:
+```yaml
+---
+- hosts: all
+  roles:
+    - postfix
+  vars:
+    - postfix_virtual_aliases:
+      - virtual: webmaster@yourdomain.com
+        alias: personal_email@gmail.com
+      - virtual: billandbob@yourdomain.com
+        alias: bill@gmail.com, bob@gmail.com
 ```
 
 A simple example that rewrites the sender address:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ postfix_install:
 postfix_hostname: "{{ ansible_fqdn }}"
 postfix_mailname: "{{ ansible_fqdn }}"
 postfix_aliases: []
+postfix_virtual_aliases: []
 postfix_sender_canonical_maps: []
 postfix_relayhost: false
 postfix_relayhost_port: 587

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,6 +8,9 @@
 - name: new aliases
   command: newaliases
 
+- name: new virtual aliases
+  command: postmap /etc/postfix/virtual
+
 - name: postmap sasl_passwd
   command: postmap hash:/etc/postfix/sasl_passwd
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,6 +85,25 @@
     - postfix
     - postfix-aliases
 
+- name: configure virtual aliases
+  lineinfile:
+    dest: /etc/postfix/virtual
+    regexp: '^{{ item.virtual }}.*'
+    line: '{{ item.virtual }} {{ item.alias }}'
+    owner: root
+    group: root
+    mode: 0644
+    create: true
+    state: present
+  with_items: "{{ postfix_virtual_aliases }}"
+  notify:
+    - new virtual aliases
+    - restart postfix
+  tags:
+    - configuration
+    - postfix
+    - postfix-virtual-aliases
+
 - name: configure sender canonical maps
   lineinfile:
     dest: /etc/postfix/sender_canonical_maps

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -31,10 +31,13 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 myhostname = {{ postfix_hostname }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
+{% if postfix_virtual_aliases %}
+virtual_alias_maps = hash:/etc/postfix/virtual
+{% endif %}
 {% if postfix_sender_canonical_maps %}
 sender_canonical_maps = hash:/etc/postfix/sender_canonical_maps
 {% endif %}
-mydestination = {{ postfix_hostname }}, localdomain, localhost, localhost.localdomain
+mydestination = {{ postfix_hostname }}, $mydomain, localdomain, localhost, localhost.localdomain
 mynetworks = {{ postfix_mynetworks | join(' ') }}
 mailbox_size_limit = 0
 recipient_delimiter = +


### PR DESCRIPTION
Adds option to use virtual aliases for non-local email forwarding. Added example to documentation.

I also added $mydomain to mydestination in the config file, since $mydomain is often different from $myhostname.