### PR TITLE
Fixed order of handlers

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,20 @@
 # handlers file for postfix
 ---
+- name: new aliases
+  command: newaliases
+
+- name: new virtual aliases
+  command: postmap /etc/postfix/virtual
+
+- name: postmap sasl_passwd
+  command: postmap hash:/etc/postfix/sasl_passwd
+
+- name: postmap sender_canonical_maps
+  command: postmap hash:/etc/postfix/sender_canonical_maps
+
+- name: postmap generic
+  command: postmap hash:/etc/postfix/generic
+
 - name: restart postfix
   command: /bin/true
   notify:
@@ -17,18 +32,3 @@
     name: postfix
     state: restarted
   when: service_default_state | default('started') == 'started'
-
-- name: new aliases
-  command: newaliases
-
-- name: new virtual aliases
-  command: postmap /etc/postfix/virtual
-
-- name: postmap sasl_passwd
-  command: postmap hash:/etc/postfix/sasl_passwd
-
-- name: postmap sender_canonical_maps
-  command: postmap hash:/etc/postfix/sender_canonical_maps
-
-- name: postmap generic
-  command: postmap hash:/etc/postfix/generic


### PR DESCRIPTION
> Handlers are run in the order they are listed, not in the order that they are notified.

see: https://docs.ansible.com/ansible/latest/reference_appendices/glossary.html#notify