### PR TITLE
Fix ansible galaxy badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## postfix
 
-[![Build Status](https://travis-ci.org/Oefenweb/ansible-postfix.svg?branch=master)](https://travis-ci.org/Oefenweb/ansible-postfix) [![Ansible Galaxy](http://img.shields.io/badge/ansible--galaxy-postfix-blue.svg)](https://galaxy.ansible.com/tersmitten/postfix)
+[![Build Status](https://travis-ci.org/Oefenweb/ansible-postfix.svg?branch=master)](https://travis-ci.org/Oefenweb/ansible-postfix) [![Ansible Galaxy](http://img.shields.io/badge/ansible--galaxy-postfix-blue.svg)](https://galaxy.ansible.com/oefenweb/postfix)
 
 Set up a postfix server in Debian-like systems.
 


### PR DESCRIPTION
## Related issue

Linked issue: #47

The repo has been moved from https://galaxy.ansible.com/tersmitten/postfix to https://galaxy.ansible.com/oefenweb/postfix. As a consequence the ansible galaxy badge in the Readme no longer points to the proper url.

## Expected behavior after merge

Ansible galaxy badge in the Readme points to the proper url.