### PR TITLE
Fix: ensure smtpd_restrictions are used even if we are not useing rel…

### DIFF
--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -28,6 +28,9 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.
 
+{% if postfix_smtpd_relay_restrictions is defined %}
+smtpd_relay_restrictions = {{ postfix_smtpd_relay_restrictions | join(', ') }}
+{% endif %}
 myhostname = {{ postfix_hostname }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
@@ -47,8 +50,11 @@ recipient_delimiter = +
 inet_interfaces = {{ postfix_inet_interfaces }}
 inet_protocols = {{ postfix_inet_protocols }}
 
-{% if postfix_relayhost %}
+{% if postfix_relayhost is defined %}
 relayhost = [{{ postfix_relayhost }}]:{{ postfix_relayhost_port }}
+{% else %}
+relayhost =
+{% endif %}
 {% if postfix_sasl_auth_enable %}
 smtp_sasl_auth_enable = {{ postfix_sasl_auth_enable | bool | ternary('yes', 'no') }}
 smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
@@ -62,12 +68,6 @@ smtp_tls_note_starttls_offer = yes
 {% if postfix_smtp_tls_cafile is defined %}
 smtp_tls_CAfile = {{ postfix_smtp_tls_cafile }}
 {% endif %}
-{% if postfix_smtpd_relay_restrictions is defined %}
-smtpd_relay_restrictions = {{ postfix_smtpd_relay_restrictions | join(', ') }}
-{% endif %}
-{% endif %}
-{% else %}
-relayhost =
 {% endif %}
 
 message_size_limit = {{  postfix_message_size_limit }}


### PR DESCRIPTION
smtpd_relay_restrictions  are not related to the relya_host settings and were not used if postfix_relayhost was not defined.
I modified the template a bit to handle this.