### PR TITLE
Default database type

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ None
  * `postfix_install` [default: `[postfix, mailutils, libsasl2-2, sasl2-bin, libsasl2-modules]`]: Packages to install
  * `postfix_hostname` [default: `{{ ansible_fqdn }}`]: Host name, used for `myhostname` and in `mydestination`
  * `postfix_mailname` [default: `{{ ansible_fqdn }}`]: Mail name (in `/etc/mailname`), used for `myorigin`
+ * `postfix_default_database_type` [default: `hash`]: Postfix default database type that supports postmap / postalias ([see](http://www.postfix.org/DATABASE_README.html#types) and [see](http://www.postfix.org/postconf.5.html#default_database_type)) 
  * `postfix_aliases` [default: `[]`]: Aliases to ensure present in `/etc/aliases`
  * `postfix_virtual_aliases` [default: `[]`]: Virtual aliases to ensure present in `/etc/postfix/virtual`
  * `postfix_sender_canonical_maps` [default: `[]`]: Sender address rewriting in `/etc/postfix/sender_canonical_maps` ([see](http://www.postfix.org/postconf.5.html#sender_canonical_maps))

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,4 @@ postfix_smtpd_banner: '$myhostname ESMTP $mail_name (Ubuntu)'
 postfix_disable_vrfy_command: false
 postfix_message_size_limit: 10240000
 postifx_header_check_format: regexp
+postfix_default_database_type: hash

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,4 @@ postfix_mynetworks:
 postfix_smtpd_banner: '$myhostname ESMTP $mail_name (Ubuntu)'
 postfix_disable_vrfy_command: false
 postfix_message_size_limit: 10240000
+postifx_header_check_format: regexp

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,6 +15,9 @@
 - name: postmap generic
   command: postmap hash:/etc/postfix/generic
 
+- name: postmap header_checks
+  command: postmap hash:/etc/postfix/header_checks
+
 - name: restart postfix
   command: /bin/true
   notify:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,19 +4,19 @@
   command: newaliases
 
 - name: new virtual aliases
-  command: postmap hash:/etc/postfix/virtual
+  command: postmap {{ postfix_default_database_type }}:/etc/postfix/virtual
 
 - name: postmap sasl_passwd
-  command: postmap hash:/etc/postfix/sasl_passwd
+  command: postmap {{ postfix_default_database_type }}:/etc/postfix/sasl_passwd
 
 - name: postmap sender_canonical_maps
-  command: postmap hash:/etc/postfix/sender_canonical_maps
+  command: postmap {{ postfix_default_database_type }}:/etc/postfix/sender_canonical_maps
 
 - name: postmap generic
-  command: postmap hash:/etc/postfix/generic
+  command: postmap {{ postfix_default_database_type }}:/etc/postfix/generic
 
 - name: postmap header_checks
-  command: postmap hash:/etc/postfix/header_checks
+  command: postmap {{ postfix_default_database_type }}:/etc/postfix/header_checks
 
 - name: restart postfix
   command: /bin/true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,11 +22,10 @@
 
 - name: install package
   apt:
-    name: "{{ item }}"
+    name: "{{ postfix_install }}"
     state: "{{ apt_install_state | default('latest') }}"
     update_cache: true
     cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
-  with_items: "{{ postfix_install }}"
   tags:
     - configuration
     - postfix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -151,6 +151,23 @@
     - postfix
     - postfix-generic-table
 
+- name: configure header checks
+  template:
+    src: etc/postfix/header_checks.j2
+    dest: /etc/postfix/header_checks
+    owner: root
+    group: root
+    mode: 0644
+  when: postfix_header_checks is defined
+  with_items: "{{ postfix_header_checks }}"
+  notify:
+    - postmap header_checks
+    - restart postfix
+  tags:
+    - configuration
+    - postfix
+    - postfix-header-checks-table
+
 - name: start and enable service
   service:
     name: postfix

--- a/templates/etc/postfix/header_checks.j2
+++ b/templates/etc/postfix/header_checks.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+{% for rule in postfix_header_checks %}
+{{ rule.pattern }} {{ rule.action }} {% if rule.text is defined %}{{ rule.text }}{% endif %}
+
+{% endfor %}

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -40,6 +40,9 @@ sender_canonical_maps = hash:/etc/postfix/sender_canonical_maps
 {% if postfix_generic %}
 smtp_generic_maps = hash:/etc/postfix/generic
 {% endif %}
+{% if postfix_header_checks is defined %}
+smtp_header_checks = regexp:/etc/postfix/header_checks
+{% endif %}
 mydestination = {{ postfix_mydestination | join(', ') }}
 mynetworks = {{ postfix_mynetworks | join(' ') }}
 mailbox_size_limit = 0

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -29,16 +29,17 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 # information on enabling SSL in the smtp client.
 
 myhostname = {{ postfix_hostname }}
-alias_maps = hash:/etc/aliases
-alias_database = hash:/etc/aliases
+default_database_type = {{ postfix_default_database_type }}
+alias_maps = {{ postfix_default_database_type }}:/etc/aliases
+alias_database = {{ postfix_default_database_type }}:/etc/aliases
 {% if postfix_virtual_aliases %}
-virtual_alias_maps = hash:/etc/postfix/virtual
+virtual_alias_maps = {{ postfix_default_database_type }}:/etc/postfix/virtual
 {% endif %}
 {% if postfix_sender_canonical_maps %}
-sender_canonical_maps = hash:/etc/postfix/sender_canonical_maps
+sender_canonical_maps = {{ postfix_default_database_type }}:/etc/postfix/sender_canonical_maps
 {% endif %}
 {% if postfix_generic %}
-smtp_generic_maps = hash:/etc/postfix/generic
+smtp_generic_maps = {{ postfix_default_database_type }}:/etc/postfix/generic
 {% endif %}
 {% if postfix_header_checks is defined %}
 smtp_header_checks = {{ postifx_header_check_format }}:/etc/postfix/header_checks
@@ -54,7 +55,7 @@ inet_protocols = {{ postfix_inet_protocols }}
 relayhost = [{{ postfix_relayhost }}]:{{ postfix_relayhost_port }}
 {% if postfix_sasl_auth_enable %}
 smtp_sasl_auth_enable = {{ postfix_sasl_auth_enable | bool | ternary('yes', 'no') }}
-smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
+smtp_sasl_password_maps = {{ postfix_default_database_type }}:/etc/postfix/sasl_passwd
 smtp_sasl_security_options = {{ postfix_sasl_security_options }}
 smtp_sasl_mechanism_filter = {{ postfix_sasl_mechanism_filter }}
 {% endif %}

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -41,7 +41,7 @@ sender_canonical_maps = hash:/etc/postfix/sender_canonical_maps
 smtp_generic_maps = hash:/etc/postfix/generic
 {% endif %}
 {% if postfix_header_checks is defined %}
-smtp_header_checks = regexp:/etc/postfix/header_checks
+smtp_header_checks = {{ postifx_header_check_format }}:/etc/postfix/header_checks
 {% endif %}
 mydestination = {{ postfix_mydestination | join(', ') }}
 mynetworks = {{ postfix_mynetworks | join(' ') }}


### PR DESCRIPTION
Added the possibility of configuring the default_database_type for all database type that support postmap.

defaults/main.yml: `postfix_default_database_type: hash`
templates/etc/postfix/main.j2: replace `hash` with variable name `{{ postfix_default_database_type }}`
handlers/main.yml: replace `hash` with variable name `{{ postfix_default_database_type }}`

Can be configured in playbook for example like: `postfix_default_database_type: btree`