### PR TITLE
Recipient canonical map

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ None
  * `postfix_install` [default: `[postfix, mailutils, libsasl2-2, sasl2-bin, libsasl2-modules]`]: Packages to install
  * `postfix_hostname` [default: `{{ ansible_fqdn }}`]: Host name, used for `myhostname` and in `mydestination`
  * `postfix_mailname` [default: `{{ ansible_fqdn }}`]: Mail name (in `/etc/mailname`), used for `myorigin`
+ * `postfix_default_database_type` [default: `hash`]: Postfix default database type that supports postmap / postalias ([see](http://www.postfix.org/DATABASE_README.html#types) and [see](http://www.postfix.org/postconf.5.html#default_database_type)) 
  * `postfix_aliases` [default: `[]`]: Aliases to ensure present in `/etc/aliases`
  * `postfix_virtual_aliases` [default: `[]`]: Virtual aliases to ensure present in `/etc/postfix/virtual`
  * `postfix_sender_canonical_maps` [default: `[]`]: Sender address rewriting in `/etc/postfix/sender_canonical_maps` ([see](http://www.postfix.org/postconf.5.html#sender_canonical_maps))
+ * `postfix_recipient_canonical_maps` [default: `[]`]: Recipient address rewriting in `/etc/postfix/recipient_canonical_maps` ([see](http://www.postfix.org/postconf.5.html#recipient_canonical_maps))
  * `postfix_generic:` [default: `[]`]: Generic table address mapping in `/etc/postfix/generic` ([see](http://www.postfix.org/generic.5.html))
  * `postfix_mydestination` [default: `["{{ postfix_hostname }}", 'localdomain', 'localhost', 'localhost.localdomain']`]: Specifies what domains this machine will deliver locally, instead of forwarding to another machine
  * `postfix_mynetworks` [default: `['127.0.0.0/8', '[::ffff:127.0.0.0]/104', '[::1]/128']`]: The list of "trusted" remote SMTP clients that have more privileges than "strangers"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ postfix_mailname: "{{ ansible_fqdn }}"
 postfix_aliases: []
 postfix_virtual_aliases: []
 postfix_sender_canonical_maps: []
+postfix_recipient_canonical_maps: []
 postfix_generic: []
 postfix_relayhost: false
 postfix_relayhost_port: 587

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,4 @@ postfix_smtpd_banner: '$myhostname ESMTP $mail_name (Ubuntu)'
 postfix_disable_vrfy_command: false
 postfix_message_size_limit: 10240000
 postifx_header_check_format: regexp
+postfix_default_database_type: hash

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,4 @@ postfix_mynetworks:
 postfix_smtpd_banner: '$myhostname ESMTP $mail_name (Ubuntu)'
 postfix_disable_vrfy_command: false
 postfix_message_size_limit: 10240000
+postifx_header_check_format: regexp

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,6 +12,9 @@
 - name: postmap sender_canonical_maps
   command: postmap {{ postfix_default_database_type }}:/etc/postfix/sender_canonical_maps
 
+- name: postmap recipient_canonical_maps
+  command: postmap {{ postfix_default_database_type }}:/etc/postfix/recipient_canonical_maps
+
 - name: postmap generic
   command: postmap {{ postfix_default_database_type }}:/etc/postfix/generic
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,6 +15,9 @@
 - name: postmap generic
   command: postmap hash:/etc/postfix/generic
 
+- name: postmap header_checks
+  command: postmap hash:/etc/postfix/header_checks
+
 - name: restart postfix
   command: /bin/true
   notify:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,19 +4,19 @@
   command: newaliases
 
 - name: new virtual aliases
-  command: postmap hash:/etc/postfix/virtual
+  command: postmap {{ postfix_default_database_type }}:/etc/postfix/virtual
 
 - name: postmap sasl_passwd
-  command: postmap hash:/etc/postfix/sasl_passwd
+  command: postmap {{ postfix_default_database_type }}:/etc/postfix/sasl_passwd
 
 - name: postmap sender_canonical_maps
-  command: postmap hash:/etc/postfix/sender_canonical_maps
+  command: postmap {{ postfix_default_database_type }}:/etc/postfix/sender_canonical_maps
 
 - name: postmap generic
-  command: postmap hash:/etc/postfix/generic
+  command: postmap {{ postfix_default_database_type }}:/etc/postfix/generic
 
 - name: postmap header_checks
-  command: postmap hash:/etc/postfix/header_checks
+  command: postmap {{ postfix_default_database_type }}:/etc/postfix/header_checks
 
 - name: restart postfix
   command: /bin/true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -151,6 +151,23 @@
     - postfix
     - postfix-generic-table
 
+- name: configure header checks
+  template:
+    src: etc/postfix/header_checks.j2
+    dest: /etc/postfix/header_checks
+    owner: root
+    group: root
+    mode: 0644
+  when: postfix_header_checks is defined
+  with_items: "{{ postfix_header_checks }}"
+  notify:
+    - postmap header_checks
+    - restart postfix
+  tags:
+    - configuration
+    - postfix
+    - postfix-header-checks-table
+
 - name: start and enable service
   service:
     name: postfix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -132,6 +132,25 @@
     - postfix
     - postfix-sender-canonical-maps
 
+- name: configure recipient canonical maps
+  lineinfile:
+    dest: /etc/postfix/recipient_canonical_maps
+    regexp: '^{{ item.recipient }}.*'
+    line: '{{ item.recipient }} {{ item.rewrite }}'
+    owner: root
+    group: root
+    mode: 0644
+    create: true
+    state: present
+  with_items: "{{ postfix_recipient_canonical_maps }}"
+  notify:
+    - postmap recipient_canonical_maps
+    - restart postfix
+  tags:
+    - configuration
+    - postfix
+    - postfix-recipient-canonical-maps
+
 - name: configure generic table
   lineinfile:
     dest: /etc/postfix/generic

--- a/templates/etc/postfix/header_checks.j2
+++ b/templates/etc/postfix/header_checks.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+{% for rule in postfix_header_checks %}
+{{ rule.pattern }} {{ rule.action }} {% if rule.text is defined %}{{ rule.text }}{% endif %}
+
+{% endfor %}

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -37,6 +37,9 @@ virtual_alias_maps = {{ postfix_default_database_type }}:/etc/postfix/virtual
 {% if postfix_sender_canonical_maps %}
 sender_canonical_maps = {{ postfix_default_database_type }}:/etc/postfix/sender_canonical_maps
 {% endif %}
+{% if postfix_recipient_canonical_maps %}
+recipient_canonical_maps = {{ postfix_default_database_type }}:/etc/postfix/recipient_canonical_maps
+{% endif %}
 {% if postfix_generic %}
 smtp_generic_maps = {{ postfix_default_database_type }}:/etc/postfix/generic
 {% endif %}

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -40,6 +40,9 @@ sender_canonical_maps = hash:/etc/postfix/sender_canonical_maps
 {% if postfix_generic %}
 smtp_generic_maps = hash:/etc/postfix/generic
 {% endif %}
+{% if postfix_header_checks is defined %}
+smtp_header_checks = regexp:/etc/postfix/header_checks
+{% endif %}
 mydestination = {{ postfix_mydestination | join(', ') }}
 mynetworks = {{ postfix_mynetworks | join(' ') }}
 mailbox_size_limit = 0

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -41,7 +41,7 @@ sender_canonical_maps = hash:/etc/postfix/sender_canonical_maps
 smtp_generic_maps = hash:/etc/postfix/generic
 {% endif %}
 {% if postfix_header_checks is defined %}
-smtp_header_checks = regexp:/etc/postfix/header_checks
+smtp_header_checks = {{ postifx_header_check_format }}:/etc/postfix/header_checks
 {% endif %}
 mydestination = {{ postfix_mydestination | join(', ') }}
 mynetworks = {{ postfix_mynetworks | join(' ') }}

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -29,16 +29,16 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 # information on enabling SSL in the smtp client.
 
 myhostname = {{ postfix_hostname }}
-alias_maps = hash:/etc/aliases
-alias_database = hash:/etc/aliases
+alias_maps = {{ postfix_default_database_type }}:/etc/aliases
+alias_database = {{ postfix_default_database_type }}:/etc/aliases
 {% if postfix_virtual_aliases %}
-virtual_alias_maps = hash:/etc/postfix/virtual
+virtual_alias_maps = {{ postfix_default_database_type }}:/etc/postfix/virtual
 {% endif %}
 {% if postfix_sender_canonical_maps %}
-sender_canonical_maps = hash:/etc/postfix/sender_canonical_maps
+sender_canonical_maps = {{ postfix_default_database_type }}:/etc/postfix/sender_canonical_maps
 {% endif %}
 {% if postfix_generic %}
-smtp_generic_maps = hash:/etc/postfix/generic
+smtp_generic_maps = {{ postfix_default_database_type }}:/etc/postfix/generic
 {% endif %}
 {% if postfix_header_checks is defined %}
 smtp_header_checks = {{ postifx_header_check_format }}:/etc/postfix/header_checks
@@ -54,7 +54,7 @@ inet_protocols = {{ postfix_inet_protocols }}
 relayhost = [{{ postfix_relayhost }}]:{{ postfix_relayhost_port }}
 {% if postfix_sasl_auth_enable %}
 smtp_sasl_auth_enable = {{ postfix_sasl_auth_enable | bool | ternary('yes', 'no') }}
-smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
+smtp_sasl_password_maps = {{ postfix_default_database_type }}:/etc/postfix/sasl_passwd
 smtp_sasl_security_options = {{ postfix_sasl_security_options }}
 smtp_sasl_mechanism_filter = {{ postfix_sasl_mechanism_filter }}
 {% endif %}


### PR DESCRIPTION
added recipient_canonical_maps same as sender_canonical_maps

don't know why it can't be built under 2.2.0, it works on my machine with this version without problems.

also contains all the changes from before:
- header_checks
- default_database_types