### PR TITLE
added possibility for recipient_canoncial_maps, identical to sender_canonical_maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ None
  * `postfix_aliases` [default: `[]`]: Aliases to ensure present in `/etc/aliases`
  * `postfix_virtual_aliases` [default: `[]`]: Virtual aliases to ensure present in `/etc/postfix/virtual`
  * `postfix_sender_canonical_maps` [default: `[]`]: Sender address rewriting in `/etc/postfix/sender_canonical_maps` ([see](http://www.postfix.org/postconf.5.html#sender_canonical_maps))
+ * `postfix_recipient_canonical_maps` [default: `[]`]: Recipient address rewriting in `/etc/postfix/recipient_canonical_maps` ([see](http://www.postfix.org/postconf.5.html#recipient_canonical_maps))
  * `postfix_generic:` [default: `[]`]: Generic table address mapping in `/etc/postfix/generic` ([see](http://www.postfix.org/generic.5.html))
  * `postfix_mydestination` [default: `["{{ postfix_hostname }}", 'localdomain', 'localhost', 'localhost.localdomain']`]: Specifies what domains this machine will deliver locally, instead of forwarding to another machine
  * `postfix_mynetworks` [default: `['127.0.0.0/8', '[::ffff:127.0.0.0]/104', '[::1]/128']`]: The list of "trusted" remote SMTP clients that have more privileges than "strangers"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ postfix_mailname: "{{ ansible_fqdn }}"
 postfix_aliases: []
 postfix_virtual_aliases: []
 postfix_sender_canonical_maps: []
+postfix_recipient_canonical_maps: []
 postfix_generic: []
 postfix_relayhost: false
 postfix_relayhost_port: 587

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,6 +12,9 @@
 - name: postmap sender_canonical_maps
   command: postmap hash:/etc/postfix/sender_canonical_maps
 
+- name: postmap recipient_canonical_maps
+  command: postmap {{ postfix_default_database_type }}:/etc/postfix/recipient_canonical_maps
+
 - name: postmap generic
   command: postmap hash:/etc/postfix/generic
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,7 +13,7 @@
   command: postmap hash:/etc/postfix/sender_canonical_maps
 
 - name: postmap recipient_canonical_maps
-  command: postmap {{ postfix_default_database_type }}:/etc/postfix/recipient_canonical_maps
+  command: postmap hash:/etc/postfix/recipient_canonical_maps
 
 - name: postmap generic
   command: postmap hash:/etc/postfix/generic

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -131,6 +131,25 @@
     - postfix
     - postfix-sender-canonical-maps
 
+- name: configure recipient canonical maps
+  lineinfile:
+    dest: /etc/postfix/recipient_canonical_maps
+    regexp: '^{{ item.recipient }}.*'
+    line: '{{ item.recipient }} {{ item.rewrite }}'
+    owner: root
+    group: root
+    mode: 0644
+    create: true
+    state: present
+  with_items: "{{ postfix_recipient_canonical_maps }}"
+  notify:
+    - postmap recipient_canonical_maps
+    - restart postfix
+  tags:
+    - configuration
+    - postfix
+    - postfix-recipient-canonical-maps
+
 - name: configure generic table
   lineinfile:
     dest: /etc/postfix/generic

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -37,6 +37,9 @@ virtual_alias_maps = hash:/etc/postfix/virtual
 {% if postfix_sender_canonical_maps %}
 sender_canonical_maps = hash:/etc/postfix/sender_canonical_maps
 {% endif %}
+{% if postfix_recipient_canonical_maps %}
+recipient_canonical_maps = {{ postfix_default_database_type }}:/etc/postfix/recipient_canonical_maps
+{% endif %}
 {% if postfix_generic %}
 smtp_generic_maps = hash:/etc/postfix/generic
 {% endif %}

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -38,7 +38,7 @@ virtual_alias_maps = hash:/etc/postfix/virtual
 sender_canonical_maps = hash:/etc/postfix/sender_canonical_maps
 {% endif %}
 {% if postfix_recipient_canonical_maps %}
-recipient_canonical_maps = {{ postfix_default_database_type }}:/etc/postfix/recipient_canonical_maps
+recipient_canonical_maps = hash:/etc/postfix/recipient_canonical_maps
 {% endif %}
 {% if postfix_generic %}
 smtp_generic_maps = hash:/etc/postfix/generic


### PR DESCRIPTION
I need to manage recipient_canonical_maps but PR #59 introducing this feature is stalled because of another feature in the same PR.

So just cherry-picking the commit for recipient_canonical_maps to have it merge quickly.

Thanks to @toebivankenoebi for the work on this feature.