### PR TITLE
Add compatibility level to config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ postfix_install:
   - libsasl2-modules
 postfix_hostname: "{{ ansible_fqdn }}"
 postfix_mailname: "{{ ansible_fqdn }}"
+postfix_config_compatibility: 2
 postfix_aliases: []
 postfix_virtual_aliases: []
 postfix_sender_canonical_maps: []

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -18,6 +18,10 @@ append_dot_mydomain = no
 
 readme_directory = no
 
+# See http://www.postfix.org/COMPATIBILITY_README.html -- default to 2 on
+# fresh installs.
+compatibility_level = {{ postfix_config_compatibility }}
+
 # TLS parameters
 smtpd_tls_cert_file={{ postfix_smtpd_tls_cert_file }}
 smtpd_tls_key_file={{ postfix_smtpd_tls_key_file }}


### PR DESCRIPTION
Debian and Ubuntu default to setting the config compatibility level to 2, without this value the postfix logs spit out errors like this

```
Sep  3 11:20:12 smtp-relay-stage postfix[3901]: Postfix is running with backwards-compatible default settings
Sep  3 11:20:12 smtp-relay-stage postfix[3901]: See http://www.postfix.org/COMPATIBILITY_README.html for details
Sep  3 11:20:12 smtp-relay-stage postfix[3901]: To disable backwards compatibility use "postconf compatibility_level=2" and "postfix reload"
```

It's a minor issue but also a relatively easy fix