### PR TITLE
Ensure aliases.db is always generated

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,7 +97,7 @@
   stat:
     path: "{{ postfix_aliases_file }}.db"
   register: aliasesdb
-  changed_when: "aliasesdb.stat.exists == False"
+  changed_when: not aliasesdb.stat.exists
   when: postfix_default_database_type == "hash"
   notify:
     - new aliases

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,6 +93,20 @@
     - postfix
     - postfix-aliases
 
+- name: check if aliases.db exists
+  stat:
+    path: "{{ postfix_aliases_file }}.db"
+  register: aliasesdb
+  changed_when: "aliasesdb.stat.exists == False"
+  when: postfix_default_database_type == "hash"
+  notify:
+    - new aliases
+    - restart postfix
+  tags:
+    - configuration
+    - postfix
+    - postfix-aliases
+
 - name: configure virtual aliases
   lineinfile:
     dest: "{{ postfix_virtual_aliases_file }}"


### PR DESCRIPTION
Postfix expects aliases.db to exist, while your role has a handler to generate it if you modify the aliases file it does not verify the file exists on a fresh install where you don't change the aliases file. The debian installer does not automatically generate the file unless you use the debconf which ansible does not, and despite you setting it up it does not run. Plus since it is necessary for postfix to run without complaint it is a good idea to check for it anyway.