### PR TITLE
Add posibility to use DNS MX records for relayhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ None
  * `postfix_inet_protocols` [default: `all`]: The Internet protocols Postfix will attempt to use when making or accepting connections ([see](http://www.postfix.org/postconf.5.html#inet_protocols))
  * `postfix_sasl_auth_enable` [default: `true`]: Enable SASL authentication in the SMTP client
  * `postfix_relayhost` [default: `false` (no relay host)]: Hostname to relay all email to
+ * `postfix_relayhost_mxlookup` [default: `false` (not using mx lookup)]: Lookup for MX record instead of A record for relayhost
  * `postfix_relayhost_port` [default: 587]: Relay port (on `postfix_relayhost`, if set)
  * `postfix_smtpd_relay_restrictions` [optional]: List of access restrictions for mail relay control ([see](http://www.postfix.org/postconf.5.html#smtpd_relay_restrictions))
  * `postfix_sasl_security_options` [default: `noanonymous`]: SMTP client SASL security options
@@ -111,6 +112,21 @@ Provide the relay host name if you want to enable relaying:
       - user: root
         alias: you@yourdomain.org
     postfix_relayhost: mail.yourdomain.org
+```
+
+Provide the relay domain name and use MX records if you want to enable relaying to DNS MX records of a domain:
+
+```yaml
+---
+- hosts: all
+  roles:
+    - postfix
+  vars:
+    postfix_aliases:
+      - user: root
+        alias: you@yourdomain.org
+    postfix_relayhost: yourdomain.org
+    postfix_relayhost_mxlookup: true
 ```
 
 Conditional relaying:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ postfix_sender_dependent_relayhost_maps: []
 postfix_header_checks: []
 postfix_generic: []
 postfix_relayhost: false
+postfix_relayhost_mxlookup: false
 postfix_relayhost_port: 587
 postfix_relaytls: false
 postfix_sasl_auth_enable: true

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -72,7 +72,11 @@ inet_protocols = {{ postfix_inet_protocols | join(', ') }}
 {% endif %}
 
 {% if postfix_relayhost %}
+{% if postfix_relayhost_mxlookup %}
+relayhost = {{ postfix_relayhost }}:{{ postfix_relayhost_port }}
+{% else %}
 relayhost = [{{ postfix_relayhost }}]:{{ postfix_relayhost_port }}
+{% endif %}
 {% if postfix_sasl_auth_enable %}
 smtp_sasl_auth_enable = {{ postfix_sasl_auth_enable | bool | ternary('yes', 'no') }}
 smtp_sasl_password_maps = {{ postfix_default_database_type }}:/etc/postfix/sasl_passwd

--- a/templates/etc/postfix/sasl_passwd.j2
+++ b/templates/etc/postfix/sasl_passwd.j2
@@ -1,3 +1,7 @@
 # {{ ansible_managed }}
 
+{% if postfix_relayhost_mxlookup %}
+{{ postfix_relayhost }}:{{ postfix_relayhost_port }}	{{ postfix_sasl_user }}:{{ postfix_sasl_password }}
+{% else %}
 [{{ postfix_relayhost }}]:{{ postfix_relayhost_port }}	{{ postfix_sasl_user }}:{{ postfix_sasl_password }}
+{% endif %}


### PR DESCRIPTION
To use the MX records of a domain as relay host, there must be no square brackets around the relayhost.
The advantage is that multiple hosts can be specified in the DNS with type MX.