### PR TITLE
added smtp_sasl_tls_security_options config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ None
  * `postfix_relayhost_port` [default: 587]: Relay port (on `postfix_relayhost`, if set)
  * `postfix_smtpd_relay_restrictions` [optional]: List of access restrictions for mail relay control ([see](http://www.postfix.org/postconf.5.html#smtpd_relay_restrictions))
  * `postfix_sasl_security_options` [default: `noanonymous`]: SMTP client SASL security options
+ * `postfix_sasl_tls_security_option` [default: `noanonymous`]: SMTP client SASL TLS security options
  * `postfix_sasl_mechanism_filter` [default: `''`]: SMTP client SASL authentication mechanism filter ([see](http://www.postfix.org/postconf.5.html#smtp_sasl_mechanism_filter))
  * `postfix_relaytls` [default: `false`]: Use TLS when sending with a relay host
  * `postfix_smtp_tls_cafile` [optional]: A file containing CA certificates of root CAs trusted to sign either remote SMTP server certificates or intermediate CA certificates (e.g. `/etc/ssl/certs/ca-certificates.crt`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,7 @@ postfix_sasl_auth_enable: true
 postfix_sasl_user: "postmaster@{{ ansible_domain }}"
 postfix_sasl_password: 'k8+haga4@#pR'
 postfix_sasl_security_options: noanonymous
+postfix_sasl_tls_security_options: noanonymous
 postfix_sasl_mechanism_filter: ''
 postfix_inet_interfaces: all
 postfix_inet_protocols: all

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -78,6 +78,7 @@ relayhost = [{{ postfix_relayhost }}]:{{ postfix_relayhost_port }}
 smtp_sasl_auth_enable = {{ postfix_sasl_auth_enable | bool | ternary('yes', 'no') }}
 smtp_sasl_password_maps = {{ postfix_default_database_type }}:/etc/postfix/sasl_passwd
 smtp_sasl_security_options = {{ postfix_sasl_security_options }}
+smtp_sasl_tls_security_options = {{ postfix_sasl_tls_security_options }}
 smtp_sasl_mechanism_filter = {{ postfix_sasl_mechanism_filter }}
 {% endif %}
 {% if postfix_relaytls %}


### PR DESCRIPTION
Hey,

for one of my servers it was needed to set the param smtp_sasl_tls_security_options, i,ve just added the param in the defaults and template.

