### PR TITLE
Manage /etc/aliases with the template module

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,16 +75,12 @@
     - postfix-sasl-passwd
 
 - name: configure aliases
-  lineinfile:
+  template:
+    src: etc/aliases.j2
     dest: "{{ postfix_aliases_file }}"
-    regexp: '^{{ item.user | regex_escape }}.*'
-    line: '{{ item.user }}: {{ item.alias }}'
     owner: root
     group: root
     mode: 0644
-    create: true
-    state: present
-  with_items: "{{ postfix_aliases }}"
   notify:
     - new aliases
     - restart postfix

--- a/templates/etc/aliases.j2
+++ b/templates/etc/aliases.j2
@@ -1,0 +1,7 @@
+{{ ansible_managed | comment }}
+# See man 5 aliases for format
+
+postmaster: root
+{% for alias in postfix_aliases %}
+{{ alias.user }}: {{ alias.alias }}
+{% endfor %}


### PR DESCRIPTION
Using the `lineinfile` module causes the deletion of aliases in the vars
files not to be reflected in the actual `/etc/aliases` file, so we may
end up with dangling entries.

Using a template to manage the whole file makes sense since this file
should be "owned" by the postfix installation/configuration, so we want
it to be rebuilt as a whole from the vars configuration instead of just
editing some lines.

Closes #78

Signed-off-by: L. Alberto Giménez <agimenez@sysvalve.es>