### PR TITLE
Fix sasl_passwd.db permissions and enable sender canonical maps to be regexp

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ postfix_smtpd_banner: '$myhostname ESMTP $mail_name (Ubuntu)'
 postfix_disable_vrfy_command: false
 postfix_message_size_limit: 10240000
 postifx_header_checks_database_type: regexp
-postifx_sender_canonical_maps_database_type: regexp
+postifx_sender_canonical_maps_database_type: ""
 postfix_default_database_type: hash
 postfix_smtpd_tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
 postfix_smtpd_tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,7 @@ postfix_smtpd_banner: '$myhostname ESMTP $mail_name (Ubuntu)'
 postfix_disable_vrfy_command: false
 postfix_message_size_limit: 10240000
 postifx_header_checks_database_type: regexp
+postifx_sender_canonical_maps_database_type: regexp
 postfix_default_database_type: hash
 postfix_smtpd_tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
 postfix_smtpd_tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,6 +11,7 @@
 
 - name: postmap sender_canonical_maps
   command: postmap {{ postifx_sender_canonical_maps_database_type }}:{{ postfix_sender_canonical_maps_file }}
+  when: postifx_sender_canonical_maps_database_type != "regexp"
 
 - name: postmap recipient_canonical_maps
   command: postmap {{ postfix_default_database_type }}:{{ postfix_recipient_canonical_maps_file }}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,10 +7,10 @@
   command: postmap {{ postfix_default_database_type }}:{{ postfix_virtual_aliases_file }}
 
 - name: postmap sasl_passwd
-  command: postmap {{ postfix_default_database_type }}:{{ postfix_sasl_passwd_file }}
+  command: postmap -p {{ postfix_default_database_type }}:{{ postfix_sasl_passwd_file }}
 
 - name: postmap sender_canonical_maps
-  command: postmap {{ postfix_default_database_type }}:{{ postfix_sender_canonical_maps_file }}
+  command: postmap {{ postifx_sender_canonical_maps_database_type }}:{{ postfix_sender_canonical_maps_file }}
 
 - name: postmap recipient_canonical_maps
   command: postmap {{ postfix_default_database_type }}:{{ postfix_recipient_canonical_maps_file }}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,7 +10,7 @@
   command: postmap -p {{ postfix_default_database_type }}:{{ postfix_sasl_passwd_file }}
 
 - name: postmap sender_canonical_maps
-  command: postmap {{ postifx_sender_canonical_maps_database_type }}:{{ postfix_sender_canonical_maps_file }}
+  command: postmap {{ postifx_sender_canonical_maps_database_type | default( postfix_default_database_type, true ) }}:{{ postfix_sender_canonical_maps_file }}
   when: postifx_sender_canonical_maps_database_type != "regexp"
 
 - name: postmap recipient_canonical_maps

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -20,7 +20,7 @@ readme_directory = no
 
 # TLS parameters
 smtpd_tls_cert_file={{ postfix_smtpd_tls_cert_file }}
-smtpd_tls_key_file={{ postfix_smtpd_tls_key_file }}
+smtpd_tls_key_file={{ postfix_smtpd_tls_key_file }}
 smtpd_use_tls=yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -36,7 +36,7 @@ alias_database = {{ postfix_default_database_type }}:{{ postfix_aliases_file }}
 virtual_alias_maps = {{ postfix_default_database_type }}:{{ postfix_virtual_aliases_file }}
 {% endif %}
 {% if postfix_sender_canonical_maps %}
-sender_canonical_maps = {{ postfix_default_database_type }}:{{ postfix_sender_canonical_maps_file }}
+sender_canonical_maps = {{ postifx_sender_canonical_maps_database_type }}:{{ postfix_sender_canonical_maps_file }}
 {% endif %}
 {% if postfix_recipient_canonical_maps %}
 recipient_canonical_maps = {{ postfix_default_database_type }}:{{ postfix_recipient_canonical_maps_file }}


### PR DESCRIPTION
As the title says:

- Run `postmap -p` on `sasl_passwd` which is mode `0600` to get `sasl_passwd.db` with mode `0644` as per official docs, otherwise the postfix service cannot see the db file and cannot get the auth info. The `*.db` file's contents are protected and do not need to be hidden.
- Hash maps are not sufficient to represent any of the meaningful updates one might want, e.g. overriding all senders or a specific set of senders not grouped on a system level, thus we need to be able to use other type of maps, such as `regexp` or `pcre`