### PR TITLE
Support for Centos 7

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,6 +60,13 @@ boxes = [
     :cpu => "50",
     :ram => "256"
   },
+  {
+    :name => "centos-7",
+    :box => "bento/centos-7",
+    :ip => '10.0.0.18',
+    :cpu => "50",
+    :ram => "256"
+  },
 ]
 
 Vagrant.configure("2") do |config|

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,13 @@ postfix_install:
   - libsasl2-2
   - sasl2-bin
   - libsasl2-modules
+postfix_redhat_install:
+  - postfix
+  - mailx
+  - cyrus-sasl
+  - cyrus-sasl-lib
+  - cyrus-sasl-plain
+  - libselinux-python
 postfix_hostname: "{{ ansible_fqdn }}"
 postfix_mailname: "{{ ansible_fqdn }}"
 postfix_aliases: []
@@ -37,7 +44,7 @@ postfix_mynetworks:
   - 127.0.0.0/8
   - '[::ffff:127.0.0.0]/104'
   - '[::1]/128'
-postfix_smtpd_banner: '$myhostname ESMTP $mail_name (Ubuntu)'
+postfix_smtpd_banner: '$myhostname ESMTP $mail_name ({{ ansible_os_family }})'
 postfix_disable_vrfy_command: false
 postfix_message_size_limit: 10240000
 postifx_header_checks_database_type: regexp

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 # defaults file for postfix
 ---
-postfix_install:
+postfix_debian_install:
   - postfix
   - mailutils
   - libsasl2-2

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   role_name: postfix
   author: Mischa ter Smitten
   company: Oefenweb.nl B.V.
-  description: Set up a postfix server in Debian-like systems
+  description: Set up a postfix server
   license: MIT
   min_ansible_version: 2.6.0
   platforms:
@@ -20,6 +20,9 @@ galaxy_info:
         - jessie
         - stretch
         - buster
+    - name: EL
+      versions:
+        - 7
   galaxy_tags:
     - system
     - web

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,6 @@
     - configuration
     - postfix
     - postfix-facts
-  when: ansible_os_family == "Debian"
 
 - name: configure debconf
   debconf:
@@ -20,6 +19,7 @@
     - configuration
     - postfix
     - postfix-install
+  when: ansible_os_family == "Debian"
 
 - name: install package
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
     - configuration
     - postfix
     - postfix-facts
+  when: ansible_os_family == "Debian"
 
 - name: configure debconf
   debconf:
@@ -21,11 +22,9 @@
     - postfix-install
 
 - name: install package
-  apt:
-    name: "{{ postfix_install }}"
-    state: "{{ apt_install_state | default('latest') }}"
-    update_cache: true
-    cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
+  package:
+    name: "{{ postfix_install|default(vars['postfix_' + ansible_os_family.lower() + '_install']) }}"
+    state: "{{ package_install_state | default('latest') }}"
   tags:
     - configuration
     - postfix

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -5,7 +5,7 @@
 # Debian specific:  Specifying a file name will cause the first
 # line of that file to be used as the name.  The Debian default
 # is /etc/mailname.
-myorigin = {{ postfix_mailname_file }}
+myorigin = {{ postfix_mailname }}
 
 smtpd_banner = {{ postfix_smtpd_banner }}
 biff = no


### PR DESCRIPTION
Added support for Centos 7, same changes than #57 but tested with latest version of your repo (PR #57 is from 2018).


