### PR TITLE
feat: add support for smtpd_client_restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ None
  * `postfix_relayhost` [default: `''` (no relay host)]: Hostname to relay all email to
  * `postfix_relayhost_mxlookup` [default: `false` (not using mx lookup)]: Lookup for MX record instead of A record for relayhost
  * `postfix_relayhost_port` [default: 587]: Relay port (on `postfix_relayhost`, if set)
+ * `postfix_smtpd_client_restrictions` [optional]: List of client restrictions ([see](http://www.postfix.org/postconf.5.html#smtpd_client_restrictions))
  * `postfix_smtpd_relay_restrictions` [optional]: List of access restrictions for mail relay control ([see](http://www.postfix.org/postconf.5.html#smtpd_relay_restrictions))
  * `postfix_sasl_security_options` [default: `noanonymous`]: SMTP client SASL security options
  * `postfix_sasl_tls_security_option` [default: `noanonymous`]: SMTP client SASL TLS security options

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -96,6 +96,9 @@ relayhost =
 {% if postfix_smtpd_relay_restrictions is defined %}
 smtpd_relay_restrictions = {{ postfix_smtpd_relay_restrictions | join(', ') }}
 {% endif %}
+{% if postfix_smtpd_client_restrictions is defined %}
+smtpd_client_restrictions = {{ postfix_smtpd_client_restrictions | join(', ') }}
+{% endif %}
 
 message_size_limit = {{  postfix_message_size_limit }}
 


### PR DESCRIPTION
Zabbix is sad when it does not see the `220 localhost ESMTP Postfix (Ubuntu)` welcome message. 😿 