### PR TITLE
Skip writing of SASL password file when SASL authentication is disabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,7 +64,9 @@
     owner: root
     group: root
     mode: 0600
-  when: postfix_relayhost | length
+  when:
+    - postfix_sasl_auth_enable | bool
+    - postfix_relayhost | length
   no_log: not ansible_check_mode
   notify:
     - postmap sasl_passwd


### PR DESCRIPTION
Setting the _relay_host_ variable doesn't necessary imply that SASL authentication is used. My use case is a German university where the relay is protected by the network.

BTW: I would always write this file to ensure idempotency when variables are changed.

