### PR TITLE
Add support for customizable database types for transport_maps, recip…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ None
  * `postfix_aliases` [default: `[]`]: Aliases to ensure present in `/etc/aliases`
  * `postfix_virtual_aliases` [default: `[]`]: Virtual aliases to ensure present in `/etc/postfix/virtual`
  * `postfix_sender_canonical_maps` [default: `[]`]: Sender address rewriting in `/etc/postfix/sender_canonical_maps` ([see](http://www.postfix.org/postconf.5.html#transport_maps))
+ * `postfix_sender_canonical_maps_database_type` [default: `"{{ postfix_default_database_type }}"`]: The database type for use in `postfix_sender_canonical_maps`
  * `postfix_recipient_canonical_maps` [default: `[]`]: Recipient address rewriting in `/etc/postfix/recipient_canonical_maps` ([see](http://www.postfix.org/postconf.5.html#sender_dependent_relayhost_maps))
+ * `postfix_recipient_canonical_maps_database_type` [default: `"{{ postfix_default_database_type }}"`]: The database type for use in `postfix_recipient_canonical_maps`
  * `postfix_transport_maps` [default: `[]`]: Transport mapping based on recipient address `/etc/postfix/transport_maps` ([see](http://www.postfix.org/postconf.5.html#recipient_canonical_maps))
+ * `postfix_transport_maps_database_type` [default: `"{{ postfix_default_database_type }}"`]: The database type for use in `postfix_transport_maps`
  * `postfix_sender_dependent_relayhost_maps` [default: `[]`]: Transport mapping based on sender address `/etc/postfix/sender_dependent_relayhost_maps` ([see](http://www.postfix.org/postconf.5.html#recipient_canonical_maps))
  * `postfix_header_checks` [default: `[]`]: Lookup tables for content inspection of primary non-MIME message headers `/etc/postfix/header_checks` ([see](http://www.postfix.org/postconf.5.html#header_checks))
  * `postfix_generic:` [default: `[]`]: Generic table address mapping in `/etc/postfix/generic` ([see](http://www.postfix.org/generic.5.html))

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,8 +11,11 @@ postfix_mailname: "{{ ansible_fqdn }}"
 postfix_aliases: []
 postfix_virtual_aliases: []
 postfix_sender_canonical_maps: []
+postfix_sender_canonical_maps_database_type: "{{ postfix_default_database_type }}"
 postfix_recipient_canonical_maps: []
+postfix_recipient_canonical_maps_database_type: "{{ postfix_default_database_type }}"
 postfix_transport_maps: []
+postfix_transport_maps_database_type: "{{ postfix_default_database_type }}"
 postfix_sender_dependent_relayhost_maps: []
 postfix_header_checks: []
 postfix_generic: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,13 +10,13 @@
   command: postmap {{ postfix_default_database_type }}:{{ postfix_sasl_passwd_file }}
 
 - name: postmap sender_canonical_maps
-  command: postmap {{ postfix_default_database_type }}:{{ postfix_sender_canonical_maps_file }}
+  command: postmap {{ postfix_sender_canonical_maps_database_type }}:{{ postfix_sender_canonical_maps_file }}
 
 - name: postmap recipient_canonical_maps
-  command: postmap {{ postfix_default_database_type }}:{{ postfix_recipient_canonical_maps_file }}
+  command: postmap {{ postfix_recipient_canonical_maps_database_type }}:{{ postfix_recipient_canonical_maps_file }}
 
 - name: postmap transport_maps
-  command: postmap {{ postfix_default_database_type }}:{{ postfix_transport_maps_file }}
+  command: postmap {{ postfix_transport_maps_database_type }}:{{ postfix_transport_maps_file }}
 
 - name: postmap sender_dependent_relayhost_maps
   command: postmap {{ postfix_default_database_type }}:{{ postfix_sender_dependent_relayhost_maps_file }}

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -36,13 +36,13 @@ alias_database = {{ postfix_default_database_type }}:{{ postfix_aliases_file }}
 virtual_alias_maps = {{ postfix_default_database_type }}:{{ postfix_virtual_aliases_file }}
 {% endif %}
 {% if postfix_sender_canonical_maps %}
-sender_canonical_maps = {{ postfix_default_database_type }}:{{ postfix_sender_canonical_maps_file }}
+sender_canonical_maps = {{ postfix_sender_canonical_maps_database_type }}:{{ postfix_sender_canonical_maps_file }}
 {% endif %}
 {% if postfix_recipient_canonical_maps %}
-recipient_canonical_maps = {{ postfix_default_database_type }}:{{ postfix_recipient_canonical_maps_file }}
+recipient_canonical_maps = {{ postfix_recipient_canonical_maps_database_type }}:{{ postfix_recipient_canonical_maps_file }}
 {% endif %}
 {% if postfix_transport_maps %}
-transport_maps = {{ postfix_default_database_type }}:{{ postfix_transport_maps_file }}
+transport_maps = {{ postfix_transport_maps_database_type }}:{{ postfix_transport_maps_file }}
 {% endif %}
 {% if postfix_sender_dependent_relayhost_maps %}
 sender_dependent_relayhost_maps = {{ postfix_default_database_type }}:{{ postfix_sender_dependent_relayhost_maps_file }}


### PR DESCRIPTION
…ient_canonical_maps, sender_canonical_maps

I introduced

* `postfix_sender_canonical_maps_database_type`
* `postfix_recipient_canonical_maps_database_type` and
* `postfix_transport_maps_database_type`

in order to be able to customize these database types in detail.