### PR TITLE
Enhancement/configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ None
  * `postfix_smtpd_tls_cert_file` [default: `/etc/ssl/certs/ssl-cert-snakeoil.pem`]: Path to certificate file
  * `postfix_smtpd_tls_key_file` [default: `/etc/ssl/certs/ssl-cert-snakeoil.key`]: Path to key file
  * `postfix_use_postscreen` [default: `false`]: Whether to use `postscreen(8)` on port 25 instead of `smtpd(8)` for [additional protection](http://www.postfix.org/POSTSCREEN_README.html).
+ * `postfix_postscreen_dnsbl_sites:` [default: `[]`]: List of DNSBL sites that `postscreen(8)` will use.
  * `postfix_raw_options` [default: `[]`]: List of lines (to pass extra (unsupported) configuration)
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ None
  * `postfix_smtpd_tls_key_file` [default: `/etc/ssl/certs/ssl-cert-snakeoil.key`]: Path to key file
  * `postfix_use_postscreen` [default: `false`]: Whether to use `postscreen(8)` on port 25 instead of `smtpd(8)` for [additional protection](http://www.postfix.org/POSTSCREEN_README.html).
  * `postfix_postscreen_dnsbl_sites:` [default: `[]`]: List of DNSBL sites that `postscreen(8)` will use.
+ * `postfix_enable_submission` [default: `false`]: Enable TLS-only submission port (587) for authenticated MUAs. Note that you will need to configure the external SASL authentication backend (`See postconf -a`)
  * `postfix_raw_options` [default: `[]`]: List of lines (to pass extra (unsupported) configuration)
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ None
  * `postfix_default_database_type` [default: `hash`]: The default database type for use in `newaliases`, `postalias` and `postmap` commands
  * `postfix_smtpd_tls_cert_file` [default: `/etc/ssl/certs/ssl-cert-snakeoil.pem`]: Path to certificate file
  * `postfix_smtpd_tls_key_file` [default: `/etc/ssl/certs/ssl-cert-snakeoil.key`]: Path to key file
+ * `postfix_use_postscreen` [default: `false`]: Whether to use `postscreen(8)` on port 25 instead of `smtpd(8)` for [additional protection](http://www.postfix.org/POSTSCREEN_README.html).
  * `postfix_raw_options` [default: `[]`]: List of lines (to pass extra (unsupported) configuration)
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ None
  * `postfix_use_postscreen` [default: `false`]: Whether to use `postscreen(8)` on port 25 instead of `smtpd(8)` for [additional protection](http://www.postfix.org/POSTSCREEN_README.html).
  * `postfix_postscreen_dnsbl_sites:` [default: `[]`]: List of DNSBL sites that `postscreen(8)` will use.
  * `postfix_enable_submission` [default: `false`]: Enable TLS-only submission port (587) for authenticated MUAs. Note that you will need to configure the external SASL authentication backend (`See postconf -a`)
+ * `postfix_enable_spf_agent` [default: `false`]: Install and enable SPF policy agent. See [Postfix SMTP Access Policy Delegation](http://www.postfix.org/SMTPD_POLICY_README.html) for furthe information.
+ * `postfix_spf_time_limit` [default: `3600`]: Default time limit to deliver messages to the SPF policy agent
  * `postfix_raw_options` [default: `[]`]: List of lines (to pass extra (unsupported) configuration)
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,4 +47,9 @@ postfix_smtpd_tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
 postfix_use_postscreen: false
 postfix_postscreen_dnsbl_sites: []
 postfix_enable_submission: false
+postfix_enable_spf_agent: false
+postfix_spf_time_limit: 3600
+postfix_spf_agent_install:
+  - postfix-policyd-spf-python
+
 postfix_raw_options: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,4 +45,5 @@ postfix_default_database_type: hash
 postfix_smtpd_tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
 postfix_smtpd_tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
 postfix_use_postscreen: false
+postfix_postscreen_dnsbl_sites: []
 postfix_raw_options: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,4 +46,5 @@ postfix_smtpd_tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
 postfix_smtpd_tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
 postfix_use_postscreen: false
 postfix_postscreen_dnsbl_sites: []
+postfix_enable_submission: false
 postfix_raw_options: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,4 +44,5 @@ postfix_header_checks_database_type: regexp
 postfix_default_database_type: hash
 postfix_smtpd_tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
 postfix_smtpd_tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
+postfix_use_postscreen: false
 postfix_raw_options: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -233,6 +233,20 @@
     - postfix
     - postfix-header-checks-table
 
+- name: configure master.cf
+  template:
+    src: templates/etc/postfix/master.cf.j2
+    dest: /etc/postfix/master.cf
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart postfix
+  tags:
+    - configuration
+    - postfix
+    - postfix-master
+
 - name: start and enable service
   service:
     name: postfix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,21 @@
     - postfix
     - postfix-install
 
+- name: install SPF policy agent
+  apt:
+    name: "{{ postfix_spf_agent_install }}"
+  tags:
+    - configuration
+    - postfix
+    - postfix-install
+  when: postfix_enable_spf_agent
+
+- name: add SPF policy service
+  set_fact:
+    postfix_smtpd_relay_restrictions: "{{ postfix_smtpd_relay_restrictions + [ 'check_policy_service unix:private/policyd-spf' ] }}"
+  when: postfix_enable_spf_agent
+
+
 - name: configure mailname
   template:
     src: "{{ postfix_mailname_file.lstrip('/') }}.j2"

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -105,6 +105,11 @@ message_size_limit = {{  postfix_message_size_limit }}
 # Disable the SMTP VRFY command. This stops some techniques used to harvest email addresses.
 disable_vrfy_command = {{ postfix_disable_vrfy_command | bool | ternary('yes', 'no') }}
 
+# Postscreen configurations
+{% if postfix_use_postscreen %}
+postscreen_dnsbl_sites = {{ postfix_postscreen_dnsbl_sites | join(', ') }}
+{% endif %}
+
 {% for raw_option in postfix_raw_options | default([]) %}
 {{ raw_option }}
 {% endfor %}

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -25,6 +25,13 @@ smtpd_use_tls=yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
+{% if postfix_enable_submission %}
+# SASL authentication from clients
+# XXX: Only implementing dovecot integration
+smtpd_sasl_type = dovecot
+smtpd_sasl_path = private/auth
+{% endif %}
+
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.
 

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -117,6 +117,10 @@ disable_vrfy_command = {{ postfix_disable_vrfy_command | bool | ternary('yes', '
 postscreen_dnsbl_sites = {{ postfix_postscreen_dnsbl_sites | join(', ') }}
 {% endif %}
 
+{% if postfix_enable_spf_agent %}
+policyd-spf_time_limit = {{ postfix_spf_time_limit }}
+{% endif %}
+
 {% for raw_option in postfix_raw_options | default([]) %}
 {{ raw_option }}
 {% endfor %}

--- a/templates/etc/postfix/master.cf.j2
+++ b/templates/etc/postfix/master.cf.j2
@@ -1,0 +1,128 @@
+{{ ansible_managed | comment }}
+#
+# Postfix master process configuration file.  For details on the format
+# of the file, see the master(5) manual page (command: "man 5 master" or
+# on-line: http://www.postfix.org/master.5.html).
+#
+# Do not forget to execute "postfix reload" after editing this file.
+#
+# ==========================================================================
+# service type  private unpriv  chroot  wakeup  maxproc command + args
+#               (yes)   (yes)   (no)    (never) (100)
+# ==========================================================================
+smtp      inet  n       -       y       -       -       smtpd
+#smtp      inet  n       -       y       -       1       postscreen
+#smtpd     pass  -       -       y       -       -       smtpd
+#dnsblog   unix  -       -       y       -       0       dnsblog
+#tlsproxy  unix  -       -       y       -       0       tlsproxy
+#submission inet n       -       y       -       -       smtpd
+#  -o syslog_name=postfix/submission
+#  -o smtpd_tls_security_level=encrypt
+#  -o smtpd_sasl_auth_enable=yes
+#  -o smtpd_tls_auth_only=yes
+#  -o smtpd_reject_unlisted_recipient=no
+#  -o smtpd_client_restrictions=$mua_client_restrictions
+#  -o smtpd_helo_restrictions=$mua_helo_restrictions
+#  -o smtpd_sender_restrictions=$mua_sender_restrictions
+#  -o smtpd_recipient_restrictions=
+#  -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
+#  -o milter_macro_daemon_name=ORIGINATING
+#smtps     inet  n       -       y       -       -       smtpd
+#  -o syslog_name=postfix/smtps
+#  -o smtpd_tls_wrappermode=yes
+#  -o smtpd_sasl_auth_enable=yes
+#  -o smtpd_reject_unlisted_recipient=no
+#  -o smtpd_client_restrictions=$mua_client_restrictions
+#  -o smtpd_helo_restrictions=$mua_helo_restrictions
+#  -o smtpd_sender_restrictions=$mua_sender_restrictions
+#  -o smtpd_recipient_restrictions=
+#  -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
+#  -o milter_macro_daemon_name=ORIGINATING
+#628       inet  n       -       y       -       -       qmqpd
+pickup    unix  n       -       y       60      1       pickup
+cleanup   unix  n       -       y       -       0       cleanup
+qmgr      unix  n       -       n       300     1       qmgr
+#qmgr     unix  n       -       n       300     1       oqmgr
+tlsmgr    unix  -       -       y       1000?   1       tlsmgr
+rewrite   unix  -       -       y       -       -       trivial-rewrite
+bounce    unix  -       -       y       -       0       bounce
+defer     unix  -       -       y       -       0       bounce
+trace     unix  -       -       y       -       0       bounce
+verify    unix  -       -       y       -       1       verify
+flush     unix  n       -       y       1000?   0       flush
+proxymap  unix  -       -       n       -       -       proxymap
+proxywrite unix -       -       n       -       1       proxymap
+smtp      unix  -       -       y       -       -       smtp
+relay     unix  -       -       y       -       -       smtp
+        -o syslog_name=postfix/$service_name
+#       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
+showq     unix  n       -       y       -       -       showq
+error     unix  -       -       y       -       -       error
+retry     unix  -       -       y       -       -       error
+discard   unix  -       -       y       -       -       discard
+local     unix  -       n       n       -       -       local
+virtual   unix  -       n       n       -       -       virtual
+lmtp      unix  -       -       y       -       -       lmtp
+anvil     unix  -       -       y       -       1       anvil
+scache    unix  -       -       y       -       1       scache
+postlog   unix-dgram n  -       n       -       1       postlogd
+#
+# ====================================================================
+# Interfaces to non-Postfix software. Be sure to examine the manual
+# pages of the non-Postfix software to find out what options it wants.
+#
+# Many of the following services use the Postfix pipe(8) delivery
+# agent.  See the pipe(8) man page for information about ${recipient}
+# and other message envelope options.
+# ====================================================================
+#
+# maildrop. See the Postfix MAILDROP_README file for details.
+# Also specify in main.cf: maildrop_destination_recipient_limit=1
+#
+maildrop  unix  -       n       n       -       -       pipe
+  flags=DRhu user=vmail argv=/usr/bin/maildrop -d ${recipient}
+#
+# ====================================================================
+#
+# Recent Cyrus versions can use the existing "lmtp" master.cf entry.
+#
+# Specify in cyrus.conf:
+#   lmtp    cmd="lmtpd -a" listen="localhost:lmtp" proto=tcp4
+#
+# Specify in main.cf one or more of the following:
+#  mailbox_transport = lmtp:inet:localhost
+#  virtual_transport = lmtp:inet:localhost
+#
+# ====================================================================
+#
+# Cyrus 2.1.5 (Amos Gouaux)
+# Also specify in main.cf: cyrus_destination_recipient_limit=1
+#
+#cyrus     unix  -       n       n       -       -       pipe
+#  user=cyrus argv=/cyrus/bin/deliver -e -r ${sender} -m ${extension} ${user}
+#
+# ====================================================================
+# Old example of delivery via Cyrus.
+#
+#old-cyrus unix  -       n       n       -       -       pipe
+#  flags=R user=cyrus argv=/cyrus/bin/deliver -e -m ${extension} ${user}
+#
+# ====================================================================
+#
+# See the Postfix UUCP_README file for configuration details.
+#
+uucp      unix  -       n       n       -       -       pipe
+  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
+#
+# Other external delivery methods.
+#
+ifmail    unix  -       n       n       -       -       pipe
+  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
+bsmtp     unix  -       n       n       -       -       pipe
+  flags=Fq. user=bsmtp argv=/usr/lib/bsmtp/bsmtp -t$nexthop -f$sender $recipient
+scalemail-backend unix	-	n	n	-	2	pipe
+  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store ${nexthop} ${user} ${extension}
+mailman   unix  -       n       n       -       -       pipe
+  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
+  ${nexthop} ${user}
+

--- a/templates/etc/postfix/master.cf.j2
+++ b/templates/etc/postfix/master.cf.j2
@@ -18,11 +18,12 @@ smtpd     pass  -       -       y       -       -       smtpd
 {% else %}
 smtp      inet  n       -       y       -       -       smtpd
 {% endif %}
-#submission inet n       -       y       -       -       smtpd
-#  -o syslog_name=postfix/submission
-#  -o smtpd_tls_security_level=encrypt
-#  -o smtpd_sasl_auth_enable=yes
-#  -o smtpd_tls_auth_only=yes
+{% if postfix_enable_submission %}
+submission inet n       -       y       -       -       smtpd
+  -o syslog_name=postfix/submission
+  -o smtpd_tls_security_level=encrypt
+  -o smtpd_sasl_auth_enable=yes
+  -o smtpd_tls_auth_only=yes
 #  -o smtpd_reject_unlisted_recipient=no
 #  -o smtpd_client_restrictions=$mua_client_restrictions
 #  -o smtpd_helo_restrictions=$mua_helo_restrictions
@@ -30,6 +31,7 @@ smtp      inet  n       -       y       -       -       smtpd
 #  -o smtpd_recipient_restrictions=
 #  -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
 #  -o milter_macro_daemon_name=ORIGINATING
+{% endif %}
 #smtps     inet  n       -       y       -       -       smtpd
 #  -o syslog_name=postfix/smtps
 #  -o smtpd_tls_wrappermode=yes

--- a/templates/etc/postfix/master.cf.j2
+++ b/templates/etc/postfix/master.cf.j2
@@ -10,11 +10,14 @@
 # service type  private unpriv  chroot  wakeup  maxproc command + args
 #               (yes)   (yes)   (no)    (never) (100)
 # ==========================================================================
+{% if postfix_use_postscreen %}
+smtp      inet  n       -       y       -       1       postscreen
+dnsblog   unix  -       -       y       -       0       dnsblog
+tlsproxy  unix  -       -       y       -       0       tlsproxy
+smtpd     pass  -       -       y       -       -       smtpd
+{% else %}
 smtp      inet  n       -       y       -       -       smtpd
-#smtp      inet  n       -       y       -       1       postscreen
-#smtpd     pass  -       -       y       -       -       smtpd
-#dnsblog   unix  -       -       y       -       0       dnsblog
-#tlsproxy  unix  -       -       y       -       0       tlsproxy
+{% endif %}
 #submission inet n       -       y       -       -       smtpd
 #  -o syslog_name=postfix/submission
 #  -o smtpd_tls_security_level=encrypt

--- a/templates/etc/postfix/master.cf.j2
+++ b/templates/etc/postfix/master.cf.j2
@@ -131,3 +131,7 @@ mailman   unix  -       n       n       -       -       pipe
   flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
   ${nexthop} ${user}
 
+{% if postfix_enable_spf_agent %}
+policyd-spf  unix  -       n       n       -       0       spawn
+  user=policyd-spf argv=/usr/bin/policyd-spf
+{% endif %}


### PR DESCRIPTION
Hi @tersmitten, this is a branch where I've been doing some work to add further options that I have in my personal mail server. The main changes are the following:

* **Manage master.cf** as a template. This is a potentially breaking change, but there are some options that need to be set here (like enabling postscreen or the submission service, part of this patch series too). I'm open to add any additional guards (like a configuration boolean to enable the "take over" of this file), but I wanted this to be as simple as possible, and based on a Debian default configuration file.
* **Add configuration to enable postscreen on port 25**. The postscreen service provides additional protection against spam for SMTP service on port 25. Enabling this boolean will configure postscreen as well as some other services. A new configuration variable has been added to add DNSBL servers for postscreen.
* **Add submission service.** According to the RFC, port 25 should be only used by servers, and users should submit mail using the submission service (587).
* **Add Dovecot SASL integration** to enable client authentication using Dovecot SASL
* **Add SPF policy agent** so we can make SPF checks on incoming mail. Note that the policy agent configuration itself is not handled with this role, only the integration with Postfix, so that should be handled otherwise (I found https://github.com/mbocquet/spf, which I don't use -yet-, but it may be interesting to add some reference).

