### PR TITLE
Ansible 2.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ dist: xenial
 language: python
 python:
   - "2.7"
-  - "3.5"
+  - "3.8"
 
 env:
   - ANSIBLE_VERSION=latest
+  - ANSIBLE_VERSION=2.9.13
   - ANSIBLE_VERSION=2.9.12
   - ANSIBLE_VERSION=2.9.11
   - ANSIBLE_VERSION=2.9.10
@@ -107,7 +108,7 @@ script:
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
 
-  - if [ "$ANSIBLE_VERSION" = "latest" ]; then ansible-lint tests/test.yml; fi
+  - if [ "$ANSIBLE_VERSION" = "latest" ] && [ "$TRAVIS_PYTHON_VERSION" != '2.7' ]; then ansible-lint tests/test.yml; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,8 @@ script:
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
 
-  - if [ "$ANSIBLE_VERSION" = "latest" ] && [ "$TRAVIS_PYTHON_VERSION" != '2.7' ]; then ansible-lint tests/test.yml; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" = '2.7' ] && [ "$ANSIBLE_VERSION" = "2.9.13" ]; then ansible-lint tests/test.yml; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != '2.7' ] && [ "$ANSIBLE_VERSION" = "latest" ]; then ansible-lint tests/test.yml; fi
 
 notifications:
   email: false


### PR DESCRIPTION
The purpose of this PR is to freeze the latest Ansible version that can run lint tests to 2.9.13 on Python 2, and upgrade Python 3 to 3.8.

This addresses https://github.com/Oefenweb/ansible-postfix/pull/99.