### PR TITLE
Add support for more smtpd restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ None
  * `postfix_relayhost_mxlookup` [default: `false` (not using mx lookup)]: Lookup for MX record instead of A record for relayhost
  * `postfix_relayhost_port` [default: 587]: Relay port (on `postfix_relayhost`, if set)
  * `postfix_smtpd_client_restrictions` [optional]: List of client restrictions ([see](http://www.postfix.org/postconf.5.html#smtpd_client_restrictions))
+ * `postfix_smtpd_helo_restrictions` [optional]: List of helo restrictions ([see](http://www.postfix.org/postconf.5.html#smtpd_helo_restrictions))
+ * `postfix_smtpd_sender_restrictions` [optional]: List of sender restrictions ([see](http://www.postfix.org/postconf.5.html#smtpd_sender_restrictions))
+ * `postfix_smtpd_recipient_restrictions` [optional]: List of recipient restrictions ([see](http://www.postfix.org/postconf.5.html#smtpd_recipient_restrictions))
  * `postfix_smtpd_relay_restrictions` [optional]: List of access restrictions for mail relay control ([see](http://www.postfix.org/postconf.5.html#smtpd_relay_restrictions))
+ * `postfix_smtpd_data_restrictions` [optional]: List of data restrictions ([see](http://www.postfix.org/postconf.5.html#smtpd_data_restrictions))
  * `postfix_sasl_security_options` [default: `noanonymous`]: SMTP client SASL security options
  * `postfix_sasl_tls_security_option` [default: `noanonymous`]: SMTP client SASL TLS security options
  * `postfix_sasl_mechanism_filter` [default: `''`]: SMTP client SASL authentication mechanism filter ([see](http://www.postfix.org/postconf.5.html#smtp_sasl_mechanism_filter))

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -93,11 +93,23 @@ smtp_tls_CAfile = {{ postfix_smtp_tls_cafile }}
 relayhost =
 {% endif %}
 
+{% if postfix_smtpd_client_restrictions is defined %}
+smtpd_client_restrictions = {{ postfix_smtpd_client_restrictions | join(', ') }}
+{% endif %}
+{% if postfix_smtpd_helo_restrictions is defined %}
+smtpd_helo_restrictions = {{ postfix_smtpd_helo_restrictions | join(', ') }}
+{% endif %}
+{% if postfix_smtpd_sender_restrictions is defined %}
+smtpd_sender_restrictions = {{ postfix_smtpd_sender_restrictions | join(', ') }}
+{% endif %}
+{% if postfix_smtpd_recipient_restrictions is defined %}
+smtpd_recipient_restrictions = {{ postfix_smtpd_recipient_restrictions | join(', ') }}
+{% endif %}
 {% if postfix_smtpd_relay_restrictions is defined %}
 smtpd_relay_restrictions = {{ postfix_smtpd_relay_restrictions | join(', ') }}
 {% endif %}
-{% if postfix_smtpd_client_restrictions is defined %}
-smtpd_client_restrictions = {{ postfix_smtpd_client_restrictions | join(', ') }}
+{% if postfix_smtpd_data_restrictions is defined %}
+smtpd_data_restrictions = {{ postfix_smtpd_data_restrictions | join(', ') }}
 {% endif %}
 
 message_size_limit = {{  postfix_message_size_limit }}


### PR DESCRIPTION
Add variables for following configuration items:

- smtpd_helo_restrictions
- smtpd_sender_restrictions
- smtpd_recipient_restrictions
- smtpd_data_restrictions
