### PR TITLE
`postfix_header_checks_database_type` variable missing from `defaults/main.yml`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ postfix_hostname: "{{ ansible_fqdn }}"
 postfix_mailname: "{{ ansible_fqdn }}"
 
 postfix_default_database_type: hash
+postfix_header_checks_database_type: regexp
 postfix_aliases: []
 postfix_virtual_aliases: []
 postfix_sender_canonical_maps: []


### PR DESCRIPTION
🔺 `postfix_header_checks_database_type = regexp` default variable is missing and causes role to fail.