### PR TITLE
Set default for postfix_disable_vrfy_command to true.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ None
  * `postfix_smtp_tls_cafile` [optional]: A file containing CA certificates of root CAs trusted to sign either remote SMTP server certificates or intermediate CA certificates (e.g. `/etc/ssl/certs/ca-certificates.crt`)
 
  * `postfix_smtpd_banner` [default: `$myhostname ESMTP $mail_name (Ubuntu)`]: Greeting banner **You MUST specify $myhostname at the start of the text. This is required by the SMTP protocol.**
- * `postfix_disable_vrfy_command` [default: `false`]: Disable the `SMTP VRFY` command. This stops some techniques used to harvest email addresses
+ * `postfix_disable_vrfy_command` [default: `true`]: Disable the `SMTP VRFY` command. This stops some techniques used to harvest email addresses
  * `postfix_message_size_limit` [default: `10240000`]: The maximal size in bytes of a message, including envelope information
 
  * `postfix_smtpd_tls_cert_file` [default: `/etc/ssl/certs/ssl-cert-snakeoil.pem`]: Path to certificate file

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,7 +54,7 @@ postfix_mynetworks:
   - '[::1]/128'
 
 postfix_smtpd_banner: '$myhostname ESMTP $mail_name (Ubuntu)'
-postfix_disable_vrfy_command: false
+postfix_disable_vrfy_command: true
 postfix_message_size_limit: 10240000
 
 postfix_smtpd_tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem


### PR DESCRIPTION
The VRFY command  can be used to see if an email address is valid on the mail server. To make existing email addresses public defies security and privacy principles, so the VRFY command should be disabled. In addition, I don't see a practical use case for the administrator of the Postfix server.