### PR TITLE
aliases: create backup when modifying file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,6 +83,7 @@
     owner: root
     group: root
     mode: 0644
+    backup: yes
   notify:
     - new aliases
     - restart postfix


### PR DESCRIPTION
When running this role on system like Debian, original content of /etc/aliases can be overwritten. This change forces Ansible to create backups.