### PR TITLE
Do not allow non-root users on mail server to read postfix_sasl_password

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,7 +9,7 @@
   when: postfix_default_database_type != 'regexp'
 
 - name: postmap sasl_passwd
-  command: postmap -p {{ postfix_default_database_type }}:{{ postfix_sasl_passwd_file }}
+  command: postmap {{ postfix_default_database_type }}:{{ postfix_sasl_passwd_file }}
   when: postfix_default_database_type != 'regexp'
 
 - name: postmap sender_canonical_maps


### PR DESCRIPTION
`sasl_password.db` is not encrypted, and can be read e.g. using the
command `string sasl_password.db`.  Change its permission mode to 0600, so
it can only be read by the file's owner, `root`.

Implemented by creating the file using `postmap`, without the `-p` flag, so
it will inherit the desired permissions from the input file
`sasl_password`.  Previously `-p` was used, to set the default mode 0644
(readable by all users).

This was tested on Debian 10, and accords with the postfix docs.

> http://www.postfix.org/SOHO_README.html
>
> Important
>
> Keep the SASL client password file in /etc/postfix, and make the file
> read+write only for root to protect the username/password combinations
> against other users. The Postfix SMTP client will still be able to read
> the SASL client passwords. It opens the file as user root before it drops
> privileges, and before entering an optional chroot jail.
>
> Use the postmap command whenever you change the /etc/postfix/sasl_passwd file.

Partial revert of commit e5e3f55bf3bd7 / #90
"Fix sasl_passwd.db permissions and enable sender canonical maps to be
regexp"

I don't know the reason that mode 0644 was believed to be necessary.

Fixes #114

---

CC @kgizdov