### PR TITLE
Added smtpd_tls mandatory protocols and ciphers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ None
 
  * `postfix_smtpd_tls_cert_file` [default: `/etc/ssl/certs/ssl-cert-snakeoil.pem`]: Path to certificate file
  * `postfix_smtpd_tls_key_file` [default: `/etc/ssl/certs/ssl-cert-snakeoil.key`]: Path to key file
+ * `postfix_smtpd_tls_mandatory_protocols` [default: `SSLv2, !SSLv3, !TLSv1, !TLSv1.1`]:
+ * `postfix_smtpd_tls_protocols` [default: `SSLv2, !SSLv3, !TLSv1, !TLSv1.1`]:
+ * `postfix_smtpd_tls_mandatory_ciphers` [default: `medium`]:
+ 
 
  * `postfix_raw_options` [default: `[]`]: List of lines (to pass extra (unsupported) configuration)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,8 +59,8 @@ postfix_message_size_limit: 10240000
 
 postfix_smtpd_tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
 postfix_smtpd_tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
-postfix_smtpd_tls_mandatory_protocols: "!SSLv2, !SSLv3, !TLSv1, !TLSv1.1"
-postfix_smtpd_tls_protocols: "!SSLv2, !SSLv3, !TLSv1, !TLSv1.1"
-postfix_smtpd_tls_mandatory_ciphers: "medium"
+postfix_smtpd_tls_mandatory_protocols: '!SSLv2, !SSLv3, !TLSv1, !TLSv1.1'
+postfix_smtpd_tls_protocols: '!SSLv2, !SSLv3, !TLSv1, !TLSv1.1'
+postfix_smtpd_tls_mandatory_ciphers: medium
 
 postfix_raw_options: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,5 +59,8 @@ postfix_message_size_limit: 10240000
 
 postfix_smtpd_tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
 postfix_smtpd_tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
+postfix_smtpd_tls_mandatory_protocols: "!SSLv2, !SSLv3, !TLSv1, !TLSv1.1"
+postfix_smtpd_tls_protocols: "!SSLv2, !SSLv3, !TLSv1, !TLSv1.1"
+postfix_smtpd_tls_mandatory_ciphers: "medium"
 
 postfix_raw_options: []

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -28,6 +28,9 @@ smtpd_tls_key_file = {{ postfix_smtpd_tls_key_file }}
 smtpd_use_tls=yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+smtpd_tls_mandatory_protocols = {{ postfix_smtpd_tls_mandatory_protocols }}
+smtpd_tls_protocols = {{ postfix_smtpd_tls_protocols  }}
+smtpd_tls_mandatory_ciphers = {{ postfix_smtpd_tls_mandatory_ciphers }}
 
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.


### PR DESCRIPTION
Hi,

Thanks for sharing you role with the community.
I decide to use it to install postfix months ago and today i needed to apply a security fix: disable tls previous version.
I noticed that the role was not capable to do so , so i enrich it with this commit.

The default values for the 3 new variables are the one recommended by https://ssl-config.mozilla.org/#server=postfix&version=3.4.8&config=intermediate&openssl=1.1.1d&guideline=5.6

Regards,
Bill