### PR TITLE
feature: smtp_tls_wrappermode for relayhost_port 465

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ None
  * `postfix_sasl_mechanism_filter` [default: `''`]: SMTP client SASL authentication mechanism filter ([see](http://www.postfix.org/postconf.5.html#smtp_sasl_mechanism_filter))
 
  * `postfix_smtp_tls_security_level` [default: `encrypt`]: The default SMTP TLS security level for the Postfix SMTP client ([see](http://www.postfix.org/postconf.5.html#smtp_tls_security_level))
+ * `postfix_smtp_tls_wrappermode` [default: `false`]: Request that the Postfix SMTP client connects using the legacy SMTPS protocol instead of using the STARTTLS command ([see](http://www.postfix.org/postconf.5.html#smtp_tls_wrappermode))
  * `postfix_smtp_tls_note_starttls_offer` [default: `true`]: Log the hostname of a remote SMTP server that offers STARTTLS, when TLS is not already enabled for that server ([see](http://www.postfix.org/postconf.5.html#smtp_tls_note_starttls_offer))
  * `postfix_smtp_tls_cafile` [optional]: A file containing CA certificates of root CAs trusted to sign either remote SMTP server certificates or intermediate CA certificates (e.g. `/etc/ssl/certs/ca-certificates.crt`)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,7 @@ postfix_sasl_tls_security_options: noanonymous
 postfix_sasl_mechanism_filter: ''
 
 postfix_smtp_tls_security_level: encrypt
+postfix_smtp_tls_wrappermode: false
 postfix_smtp_tls_note_starttls_offer: true
 
 postfix_inet_interfaces: all

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -88,6 +88,7 @@ smtp_sasl_mechanism_filter = {{ postfix_sasl_mechanism_filter }}
 {% if postfix_relaytls %}
 smtp_use_tls = {{ postfix_relaytls | bool | ternary('yes', 'no') }}
 smtp_tls_security_level = {{ postfix_smtp_tls_security_level }}
+smtp_tls_wrappermode = {{ postfix_smtp_tls_wrappermode | bool | ternary('yes', 'no') }}
 smtp_tls_note_starttls_offer = {{ postfix_smtp_tls_note_starttls_offer | bool | ternary('yes', 'no') }}
 {% if postfix_smtp_tls_cafile is defined %}
 smtp_tls_CAfile = {{ postfix_smtp_tls_cafile }}


### PR DESCRIPTION
Request that the Postfix SMTP client connects using the legacy SMTPS protocol instead of using the STARTTLS command.
Postfix needs the following setting in `main.cf` if the `relayhost` uses port `465`.
```
smtp_tls_wrappermode = yes
```
http://www.postfix.org/postconf.5.html#smtp_tls_wrappermode