### PR TITLE
Add support for smtp_bind_address* parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ None
  * `postfix_mynetworks` [default: `['127.0.0.0/8', '[::ffff:127.0.0.0]/104', '[::1]/128']`]: The list of "trusted" remote SMTP clients that have more privileges than "strangers"
  * `postfix_inet_interfaces` [default: `all`]: Network interfaces to bind ([see](http://www.postfix.org/postconf.5.html#inet_interfaces))
  * `postfix_inet_protocols` [default: `all`]: The Internet protocols Postfix will attempt to use when making or accepting connections ([see](http://www.postfix.org/postconf.5.html#inet_protocols))
-
+* `postfix_smtp_ipv6_bind` [default: empty]: Outbound network interfaces to use (IpV6) ([see](http://www.postfix.org/postconf.5.html#smtp_bind_address6))
+* `postfix_smtp_ipv4_bind` [default: `all`]: Outbound network interfaces to use (IpV4) ([see](http://www.postfix.org/postconf.5.html#smtp_bind_address))
+* 
  * `postfix_relayhost` [default: `''` (no relay host)]: Hostname to relay all email to
  * `postfix_relayhost_mxlookup` [default: `false` (not using mx lookup)]: Lookup for MX record instead of A record for relayhost
  * `postfix_relayhost_port` [default: 587]: Relay port (on `postfix_relayhost`, if set)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,8 @@ postfix_smtp_tls_wrappermode: false
 postfix_smtp_tls_note_starttls_offer: true
 
 postfix_inet_interfaces: all
+postfix_smtp_ipv6_bind: ''
+postfix_smtp_ipv4_bind: all
 postfix_inet_protocols: all
 postfix_mydestination:
   - "{{ postfix_hostname }}"

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -66,6 +66,12 @@ inet_interfaces = {{ postfix_inet_interfaces }}
 {% else %}
 inet_interfaces = {{ postfix_inet_interfaces | join(', ') }}
 {% endif %}
+{% if postfix_smtp_ipv4_bind %}
+smtp_bind_address = {{ postfix_smtp_ipv4_bind }}
+{% endif %}
+{% if postfix_smtp_ipv6_bind %}
+smtp_bind_address6 = {{ postfix_smtp_ipv6_bind }}
+{% endif %}
 {% if postfix_inet_protocols is string %}
 inet_protocols = {{ postfix_inet_protocols }}
 {% else %}


### PR DESCRIPTION
Because I need to specify  which interface my postfix should use when sending e-mails