### PR TITLE
debconf fails on non Debian systems

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,7 @@
     - configuration
     - postfix
     - postfix-install
+  when: ansible_os_family == "Debian"
 
 - name: install package
   apt:


### PR DESCRIPTION
Added filter to "configure debconf" to only run on Debian based systems