### PR TITLE
Modify aliases template for regexp entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,20 @@ Conditional relaying:
         result: "smtp:{{ ansible_lo['ipv4']['address'] }}:1025"
 ```
 
+Aliases with regexp table:
+
+```yaml
+---
+- hosts: all
+  roles:
+    - oefenweb.postfix
+  vars:
+    postfix_default_database_type: regexp
+    postfix_aliases:
+      - user: /.*/
+        alias: you@yourdomain.org
+```
+
 For AWS SES support:
 
 ```yaml

--- a/templates/etc/aliases.j2
+++ b/templates/etc/aliases.j2
@@ -1,7 +1,13 @@
 {{ ansible_managed | comment }}
 # See man 5 aliases for format
 
+{% if postfix_default_database_type == "regexp" %}
+{% for alias in postfix_aliases %}
+{{ alias.user }} {{ alias.alias }}
+{% endfor %}
+{% else %}
 postmaster: root
 {% for alias in postfix_aliases %}
 {{ alias.user }}: {{ alias.alias }}
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
This was already discussed in #88 and was supposedly fixed, but did not work for me. Now aliases are possible with correct regexp format (no colon). Alias for postmaster is omitted in that case (incorrect regexp format with colon). Defaults are unchanged.