### PR TITLE
Support smtpd_tls_security_level option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ None
  * `postfix_smtpd_tls_cert_file` [default: `/etc/ssl/certs/ssl-cert-snakeoil.pem`]: Path to certificate file
  * `postfix_smtpd_tls_key_file` [default: `/etc/ssl/certs/ssl-cert-snakeoil.key`]: Path to key file
 
+ * `postfix_smtpd_security_level` [optional]: The SMTP TLS security level for the Postfix SMTP server ([see](http://www.postfix.org/postconf.5.html#smtpd_tls_security_level))
  * `postfix_raw_options` [default: `[]`]: List of lines (to pass extra (unsupported) configuration)
 
 ## Dependencies

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -27,6 +27,9 @@ smtpd_tls_cert_file = {{ postfix_smtpd_tls_cert_file }}
 smtpd_tls_key_file = {{ postfix_smtpd_tls_key_file }}
 smtpd_use_tls=yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
+{% if postfix_smtpd_tls_security_level is defined -%}
+smtpd_tls_security_level = {{ postfix_smtpd_tls_security_level }}
+{% endif %}
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for


### PR DESCRIPTION
This PR adds support for **smtpd_security_level** option ([here](http://www.postfix.org/postconf.5.html#smtpd_tls_security_level)). If the variable is undefined then no changes (including linefeeds) are introduced to main.cf.