### PR TITLE
Option to set alias database type to regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ None
  * `postfix_compatibility_level` [optional]: With backwards compatibility turned on (the compatibility_level value is less than the Postfix built-in value), Postfix looks for settings that are left at their implicit default value, and logs a message when a backwards-compatible default setting is required (e.g. `2`, `Postfix >= 3.0`)
 
  * `postfix_default_database_type` [default: `hash`]: The default database type for use in `newaliases`, `postalias` and `postmap` commands
+ * `postfix_alias_database_type` [default: `"{{ postfix_default_database_type }}"`]: The database type for aliases
  * `postfix_aliases` [default: `[]`]: Aliases to ensure present in `/etc/aliases`
  * `postfix_virtual_aliases` [default: `[]`]: Virtual aliases to ensure present in `/etc/postfix/virtual`
  * `postfix_sender_canonical_maps` [default: `[]`]: Sender address rewriting in `/etc/postfix/sender_canonical_maps` ([see](http://www.postfix.org/postconf.5.html#transport_maps))
@@ -176,7 +177,7 @@ Conditional relaying:
         result: "smtp:{{ ansible_lo['ipv4']['address'] }}:1025"
 ```
 
-Aliases with regexp table:
+Aliases with regexp table (forward all local mail to specified address):
 
 ```yaml
 ---
@@ -184,7 +185,7 @@ Aliases with regexp table:
   roles:
     - oefenweb.postfix
   vars:
-    postfix_default_database_type: regexp
+    postfix_alias_database_type: regexp
     postfix_aliases:
       - user: /.*/
         alias: you@yourdomain.org

--- a/README.md
+++ b/README.md
@@ -176,6 +176,20 @@ Conditional relaying:
         result: "smtp:{{ ansible_lo['ipv4']['address'] }}:1025"
 ```
 
+Aliases with regexp table:
+
+```yaml
+---
+- hosts: all
+  roles:
+    - oefenweb.postfix
+  vars:
+    postfix_default_database_type: regexp
+    postfix_aliases:
+      - user: /.*/
+        alias: you@yourdomain.org
+```
+
 For AWS SES support:
 
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ postfix_hostname: "{{ ansible_fqdn }}"
 postfix_mailname: "{{ ansible_fqdn }}"
 
 postfix_default_database_type: hash
+postfix_alias_database_type: "{{ postfix_default_database_type }}"
 postfix_aliases: []
 postfix_virtual_aliases: []
 postfix_sender_canonical_maps: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,7 +3,7 @@
 - name: new aliases
   ansible.builtin.command: >
     newaliases
-  when: postfix_default_database_type != 'regexp'
+  when: postfix_alias_database_type != 'regexp'
   changed_when: true
 
 - name: new virtual aliases

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,7 +96,7 @@
     path: "{{ postfix_aliases_file }}.db"
   register: _aliasesdb
   changed_when: not _aliasesdb.stat.exists
-  when: postfix_default_database_type == 'hash'
+  when: postfix_alias_database_type == 'hash'
   notify:
     - new aliases
     - restart postfix

--- a/templates/etc/aliases.j2
+++ b/templates/etc/aliases.j2
@@ -1,7 +1,13 @@
 {{ ansible_managed | comment }}
 # See man 5 aliases for format
 
+{% if postfix_default_database_type == "regexp" %}
+{% for alias in postfix_aliases %}
+{{ alias.user }} {{ alias.alias }}
+{% endfor %}
+{% else %}
 postmaster: root
 {% for alias in postfix_aliases %}
 {{ alias.user }}: {{ alias.alias }}
 {% endfor %}
+{% endif %}

--- a/templates/etc/aliases.j2
+++ b/templates/etc/aliases.j2
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 # See man 5 aliases for format
 
-{% if postfix_default_database_type == "regexp" %}
+{% if postfix_alias_database_type == "regexp" %}
 {% for alias in postfix_aliases %}
 {{ alias.user }} {{ alias.alias }}
 {% endfor %}

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -34,8 +34,8 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
 myhostname = {{ postfix_hostname }}
 default_database_type = {{ postfix_default_database_type }}
-alias_maps = {{ postfix_default_database_type }}:{{ postfix_aliases_file }}
-alias_database = {{ postfix_default_database_type }}:{{ postfix_aliases_file }}
+alias_maps = {{ postfix_alias_database_type }}:{{ postfix_aliases_file }}
+alias_database = {{ postfix_alias_database_type }}:{{ postfix_aliases_file }}
 {% if postfix_virtual_aliases %}
 virtual_alias_maps = {{ postfix_default_database_type }}:{{ postfix_virtual_aliases_file }}
 {% endif %}


### PR DESCRIPTION
This PR allows configuring `alias_database` as `regexp`. This topic was already discussed in issue #88, but could not work because the alias db syntax was incorrect for regexp type (containing a colon between user and alias).

A new option `postfix_alias_database_type` was introduced which is used for `alias_database` and `alias_maps` when specified (`postfix_default_database_type` is used otherwise), and a correct regexp database file is created from the `postfix_aliases` list.

