### PR TITLE
Accept email on localhost by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,11 @@ postfix_mynetworks:
   - '[::1]/128'
 
 postfix_smtpd_banner: '$myhostname ESMTP $mail_name (Ubuntu)'
+
+postfix_smtpd_relay_restrictions:
+  - permit_mynetworks
+  - reject
+
 postfix_disable_vrfy_command: true
 postfix_message_size_limit: 10240000
 


### PR DESCRIPTION
I believe email should be accepted on localhost by default.

Therefore I propose this change.

Any reason this should not be the case?