### PR TITLE
ansible managed syntax, refs #146

### DIFF
--- a/templates/etc/postfix/header_checks.j2
+++ b/templates/etc/postfix/header_checks.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 {% for rule in postfix_header_checks | default([]) %}
 {{ rule.pattern }} {{ rule.action }} {% if rule.text is defined %}{{ rule.text }}{% endif %}
 

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 # See /usr/share/postfix/main.cf.dist for a commented, more complete version
 

--- a/templates/etc/postfix/sasl_passwd.j2
+++ b/templates/etc/postfix/sasl_passwd.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {% if postfix_relayhost_mxlookup %}
 {{ postfix_relayhost }}:{{ postfix_relayhost_port }}	{{ postfix_sasl_user }}:{{ postfix_sasl_password }}


### PR DESCRIPTION
This allows having multi-line `ansible_managed` strings. See https://github.com/Oefenweb/ansible-postfix/issues/146