### PR TITLE
make sure this evaluates to boolean

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,7 +65,7 @@
     group: root
     mode: '0600'
   when:
-    - postfix_relayhost | length
+    - postfix_relayhost | length > 0
     - postfix_sasl_auth_enable | bool
   no_log: "{{ not ansible_check_mode }}"
   notify:


### PR DESCRIPTION
newer Ansible enforces this. 
See: https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_12.html#example-implicit-boolean-conversion
