### PR TITLE
Fix INJECT_FACTS_AS_VARS deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ None
 #### Variables
 
  * `postfix_install` [default: `[postfix, mailutils, libsasl2-2, sasl2-bin, libsasl2-modules]`]: Packages to install
- * `postfix_hostname` [default: `{{ ansible_fqdn }}`]: Host name, used for `myhostname` and in `mydestination`
- * `postfix_mailname` [default: `{{ ansible_fqdn }}`]: Mail name (in `/etc/mailname`), used for `myorigin`
+ * `postfix_hostname` [default: `{{ ansible_facts['fqdn'] }}`]: Host name, used for `myhostname` and in `mydestination`
+ * `postfix_mailname` [default: `{{ ansible_facts['fqdn'] }}`]: Mail name (in `/etc/mailname`), used for `myorigin`
 
  * `postfix_compatibility_level` [optional]: With backwards compatibility turned on (the compatibility_level value is less than the Postfix built-in value), Postfix looks for settings that are left at their implicit default value, and logs a message when a backwards-compatible default setting is required (e.g. `2`, `Postfix >= 3.0`)
 
@@ -55,7 +55,7 @@ None
  * `postfix_smtpd_data_restrictions` [optional]: List of data restrictions ([see](http://www.postfix.org/postconf.5.html#smtpd_data_restrictions))
 
  * `postfix_sasl_auth_enable` [default: `true`]: Enable SASL authentication in the SMTP client
- * `postfix_sasl_user` [default: `postmaster@{{ ansible_domain }}`]: SASL relay username
+ * `postfix_sasl_user` [default: `postmaster@{{ ansible_facts['domain'] }}`]: SASL relay username
  * `postfix_sasl_password` [default: `k8+haga4@#pR`]: SASL relay password **Make sure to change!**
  * `postfix_sasl_security_options` [default: `noanonymous`]: SMTP client SASL security options
  * `postfix_sasl_tls_security_option` [default: `noanonymous`]: SMTP client SASL TLS security options

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,8 @@ postfix_install:
   - sasl2-bin
   - libsasl2-modules
 
-postfix_hostname: "{{ ansible_fqdn }}"
-postfix_mailname: "{{ ansible_fqdn }}"
+postfix_hostname: "{{ ansible_facts['fqdn'] }}"
+postfix_mailname: "{{ ansible_facts['fqdn'] }}"
 
 postfix_default_database_type: hash
 postfix_aliases: []
@@ -33,7 +33,7 @@ postfix_relayhost_port: 587
 postfix_relaytls: false
 
 postfix_sasl_auth_enable: true
-postfix_sasl_user: "postmaster@{{ ansible_domain }}"
+postfix_sasl_user: "postmaster@{{ ansible_facts['domain'] }}"
 postfix_sasl_password: 'k8+haga4@#pR'
 postfix_sasl_security_options: noanonymous
 postfix_sasl_tls_security_options: noanonymous

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   block:
     - name: facts | set | is_docker_guest
       ansible.builtin.set_fact:
-        is_docker_guest: "{{ ansible_virtualization_role | default('host') == 'guest' and ansible_virtualization_type | default('none') == 'docker' }}"
+        is_docker_guest: "{{ ansible_facts['virtualization_role'] | default('host') == 'guest' and ansible_facts['virtualization_type'] | default('none') == 'docker' }}"
 
     - name: facts | set | postfix_relayhosts
       ansible.builtin.set_fact:


### PR DESCRIPTION
Ansible 2.18 deprecated accessing facts like `ansible_fqdn` directly, preferring `ansible_facts['fqdn']` instead. This will become an error in a future Ansible release.

Updated fact references:
- `ansible_fqdn` -> `ansible_facts['fqdn']`
- `ansible_domain` -> `ansible_facts['domain']`
- `ansible_virtualization_role` -> `ansible_facts['virtualization_role']`
- `ansible_virtualization_type` -> `ansible_facts['virtualization_type']`

See: https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars