### PR TITLE
fix: add guards for debian family specific calls

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,8 @@
     - configuration
     - postfix
     - postfix-install
+  when:
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: install package
   ansible.builtin.apt:
@@ -39,6 +41,8 @@
     - configuration
     - postfix
     - postfix-install
+  when:
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: configure mailname
   ansible.builtin.template:


### PR DESCRIPTION
Hey oefenweb,

Thank you for this package, I have been using it for years.

I just wanted to add a small guard around to make this purely a configuration role without making it per operating system or running this with tags.

- Adds a guard around the `debian` OS family cases.